### PR TITLE
Fixed the config not updating by loading in values from config.lua directly instead of through SMODS

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -3,7 +3,7 @@ return {
     ["NEURO_SDK_WS_URL"] = "ws://127.0.0.1:8000",
 
     -- Delay in seconds before attempting to reconnect
-    ["RECONNECT_DELAY"] = 2,
+    ["RECONNECT_DELAY"] = 5,
 
     -- The profile Neuro should use. If save data exists in this slot, we are going to assume it belongs to Neuro and
     -- continue the game from there if there's an active run. If there's no save data, we will create a new

--- a/game-sdk/websocket/websocket_connection.lua
+++ b/game-sdk/websocket/websocket_connection.lua
@@ -15,8 +15,8 @@ local json = ModCache.load("libs/json.lua")
 local WebsocketConnection = {}
 WebsocketConnection.__index = WebsocketConnection
 
-local RECONNECT_DELAY = SMODS.current_mod.config["RECONNECT_DELAY"] or 5
-local WS_URL = SMODS.current_mod.config["NEURO_SDK_WS_URL"]
+local RECONNECT_DELAY = NeuroConfig.RECONNECT_DELAY or 5
+local WS_URL = NeuroConfig.NEURO_SDK_WS_URL
 
 function WebsocketConnection:new()
     local self = setmetatable({}, WebsocketConnection)

--- a/get_text.lua
+++ b/get_text.lua
@@ -1,7 +1,7 @@
 require "functions/misc_functions"
 
-local ALLOWED_DECKS = SMODS.current_mod.config.ALLOWED_DECKS
-local ALLOWED_STAKES = SMODS.current_mod.config.ALLOWED_DECKS
+local ALLOWED_DECKS = NeuroConfig.ALLOWED_DECKS
+local ALLOWED_STAKES = NeuroConfig.ALLOWED_DECKS
 
 local getText = {}
 

--- a/hook.lua
+++ b/hook.lua
@@ -5,8 +5,8 @@ local SelectDeck = ModCache.load("custom-actions/select_deck.lua")
 local Hook = {}
 Hook.__index = Hook
 
-local neuro_profile = SMODS.current_mod.config["PROFILE_SLOT"]
-local should_unlock = SMODS.current_mod.config.UNLOCK_ALL
+local neuro_profile = NeuroConfig.PROFILE_SLOT
+local should_unlock = NeuroConfig.UNLOCK_ALL
 
 local function load_profile(delay)
     G.E_MANAGER:add_event(Event({

--- a/main.lua
+++ b/main.lua
@@ -3,11 +3,14 @@ assert(SMODS.load_file("game-sdk/utils/table_utils.lua"))()
 assert(SMODS.load_file("game-sdk/sdk_string_consts.lua"))()
 
 ModCache = assert(SMODS.load_file("module_cache.lua"))()
+NeuroConfig = ModCache.load("config.lua")
 
 -- unlike require(), SMODS.load_file() doesn't guarantee files will only get loaded once
 -- use ModCache.load() to get them loaded once
 -- theres definitely a way to get the sdk working with SMODS.load_file, but the entire sdk was written for require()
 -- and i wanted to do minimal changes to get it all working
 local Hook = ModCache.load("hook.lua")
+
+
 
 Hook.hook_game()


### PR DESCRIPTION
`SMODS.current_mod.config` loads config values from a .jkr file that's created based off of your config.lua when the mod is loaded in for the first time. This means that future changes to config.lua won't appear in the .jkr file. The intended way to load configs through SMODS is by creating a [Config UI Tab](https://github.com/Steamodded/smods/wiki/Mod-functions#modconfig_tab) that automatically updates the .jkr file.

For our use case, a config UI is not ideal since it requires list inputs and a lot of arbitrary text input, and the neuro API documentation says the preferable way to handle configs is through a file anyway. So instead of doing it the intended way through SMODS I decided to instead manually import the config file in the same way we do any other file. 

TL;DR - Use `NeuroConfig.key` instead of `SMODS.current_mod.config.key` when grabbing config values 

