### PR TITLE
Play card action

### DIFF
--- a/custom-actions/play_cards.lua
+++ b/custom-actions/play_cards.lua
@@ -1,5 +1,6 @@
 local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
 local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
+local GetText = ModCache.load("get_text.lua")
 
 local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
 
@@ -27,10 +28,24 @@ function PlayCards:_get_schema()
 			type = "array",
             items = {
 				type = "string",
-				enum = self:_get_hand()
+				enum = GetText:get_hand_seals() -- TODO: change to editions --GetText:get_hand_editions()
 			},
 		}
     })
+end
+
+local function increment_card_table(table)
+    local selected_table = {}
+    for _, card in pairs(table) do
+        if selected_table[card] == nil then
+            sendDebugMessage("setting " .. card .. "to 1")
+            selected_table[card] = 1
+        else
+            sendDebugMessage("adding 1 to " .. card)
+            selected_table[card] = selected_table[card] + 1 -- should increment for each type of card in hand
+        end
+    end
+    return selected_table
 end
 
 function PlayCards:_validate_action(data, state)
@@ -53,7 +68,7 @@ function PlayCards:_validate_action(data, state)
 
     if #selected_hand > 5 then return ExecutionResult.failure("Cannot play more than 5 cards.") end
 
-	local hand = self:_get_hand() -- check hand to see if has selected more than are available
+	local hand = GetText:get_hand_enhancements() --TODO: change to editions later -- check hand to see if has selected more than are available
     local selected_amount = {}
     local hand_amount = {}
 
@@ -66,29 +81,11 @@ function PlayCards:_validate_action(data, state)
         end
     end
 
-    --TODO: dont repeate this code as much
-
     -- add one for each card that is in the hand
-    for _, card in pairs(hand) do
-        if hand_amount[card] == nil then
-            sendDebugMessage("setting " .. card .. "to 1 on hand")
-            hand_amount[card] = 1
-        else
-            sendDebugMessage("adding 1 to " .. card .. " on hand")
-            hand_amount[card] = hand_amount[card] + 1 -- should increment for each type of card in hand
-        end
-    end
+    hand_amount = increment_card_table(hand)
 
     -- add one for each card that is in the selected hand
-    for _, card in pairs(selected_hand) do
-        if selected_amount[card] == nil then
-            sendDebugMessage("setting " .. card .. "to 1")
-            selected_amount[card] = 1
-        else
-            sendDebugMessage("adding 1 to " .. card)
-            selected_amount[card] = selected_amount[card] + 1 -- should increment for each type of card in hand
-        end
-    end
+    selected_amount = increment_card_table(selected_hand)
 
     -- get if trying to play more cards than in hand
     for _, card in pairs(selected_hand) do
@@ -118,9 +115,10 @@ function PlayCards:_execute_action(state)
 
 
     local play_button = G.buttons:get_UIE_by_ID('play_button')
-    local hand_string = self:_get_hand()
+    local hand_string = GetText:get_hand_enhancements() -- TODO: change back to editions
     local hand = G.hand.cards
-    for location, card in pairs(selected_hand) do -- TODO: find way too include position of card in hand as right now it will do card 1-5
+
+    for location, card in pairs(selected_hand) do
         for index = 1, #hand_string, 1  do
             if card == hand_string[index] then
                 G.hand:add_to_highlighted(hand[index])
@@ -142,140 +140,6 @@ function PlayCards:_execute_action(state)
 
 	return true
 end
-
- -- foil var localize: G.P_CENTERS.e_foil.config.extra
-local function get_edition_args(name,card_config)
-    sendDebugMessage(tprint(card_config,1,2))
-    local loc_args = {}
-    if name == "foil" then loc_args = {card_config.config.extra} end -- returns 50 as foil adds 50 chips
-    -- if name == "foil" then loc_args = {localize{type = 'name_text', key = 'e_foil', set='G.P_CENTERS.e_foil.config.extra'}} end
-    return loc_args
-end
-
-function PlayCards:_get_hand() -- G.hand.cards  G.play.cards
-	local cards = {}
-	for pos, card in ipairs(G.hand.cards) do -- Can get editions with card.edition / enhancements with card.ability / seal with card.seal
-
-        local name = card.base.name
-
-        sendDebugMessage("card edition " .. tostring(card.config))
-
-        if card.edition then
-            local key_override
-            for _, v in pairs(G.P_CENTER_POOLS.Edition) do
-                local loc_args,loc_nodes = get_edition_args(card.edition.type,G.P_CENTERS[v.key]), {} -- idk why G.P_CENTERS contains the extra's details but it works
-                sendDebugMessage("original_key: " .. tostring(v.original_key) .. " edition type: " .. tostring(card.edition.type))
-                sendDebugMessage(tprint(v,1,2))
-                sendDebugMessage("v: " .. tostring(v) .. " v type " .. type(v))
-                if v.original_key ~= card.edition.type then goto continue end
-                if v.loc_vars and type(v.loc_vars) == 'function' then
-                    -- local res = v:loc_vars() or {}
-                    loc_args = v.vars or loc_args
-                    key_override = v.key
-                    sendDebugMessage("key: " .. v.key .. " vars " .. tprint(loc_args,1,2))
-                    -- sendDebugMessage("loc_vars: " .. v:loc_vars())
-
-                    localize{type = "descriptions", set = 'Edition',key= key_override or card.key, nodes = loc_nodes, vars = loc_args}
-                    sendDebugMessage("loc_vars " .. tostring(card.loc_vars) .. " type " .. type(card.loc_vars))
-                    -- sendDebugMessage("override " .. key_override)
-
-                    sendDebugMessage("loc_args " .. tostring(loc_args[1]) .. " loc_nodes " .. tostring(loc_nodes[1]))
-
-                    local description = ""
-                    sendDebugMessage("before loc_nodes for " .. tostring(table.get_keys(loc_nodes)))
-                    for _, line in ipairs(loc_nodes) do
-                        for _, v in ipairs(line) do
-                            sendDebugMessage("Text: " .. v.config.text)
-                            description = description .. v.config.text
-                        end
-                        description = description
-                    end
-
-                    name = name .. description
-                end
-            ::continue::
-            end
-
-        -- for _, desc in pairs(G.P_CENTERS.e_foil) do
-        --     if desc.loc_vars and type(desc.loc_vars) == 'function' then
-        --         local res = desc:loc_vars() or {}
-        --         loc_args = res.vars or {}
-        --         key_override = res.key
-        --     end
-        -- end
-
-
-        --TODO: change this to get from localize like select_deck
-
-        -- if card.ability.name == "Bonus Card" then
-        --     name = name .. " Enhancement: Bonus Card: +30 chips"
-        -- elseif card.ability.name == "Mult Card" then
-        --     name = name .. " Enhancement: Bonus Card: 	+4 Mult"
-        -- end
-
-        -- if edition == nil then
-        --     goto continue
-        -- end
-
-        -- -- this should probably be changed for modding support but good enough for vanilla
-        -- if card.edition.foil then
-        --     name = name .. " edition: Foil: +50 chips when scored."
-        -- elseif card.edition.holo then
-        --     name = name .. " edition: Holographic: +10 Mult when scored."
-        -- elseif card.edition.polychrome then
-        --     name = name .. " edition: Polychrome: X1.5 Mult when scored."
-        -- elseif card.edition == nil then
-        --     name = name
-        -- end
-        -- elseif card.edition.negative then -- this is unused in vanilla (according to the wiki)
-        --     name = " edition: Negative: +1 hand size"
-
-		cards[#cards+1] = name -- this will give to neuro as "{value} of {suit}"
-        end
-    end
-    return cards
-end
-
--- self.edition
--- chips: integer = 50,
--- foil: boolean = true,
--- holo: boolean = true,
--- mult: integer = 10,
--- negative: boolean = true,
--- polychrome: boolean = true,
--- type: string = 'foil'|'holo'|'negative'|'polychrome',
--- x_mult: number = 1.5,
-
--- self.ability
-
--- bonus: integer,
--- burnt_hand: integer = 0,
--- caino_xmult: integer = 1,
--- consumeable: unknown,
--- d_size: integer = 0,
--- effect: unknown,
--- extra: table,
--- extra_value: integer = 0,
--- forced_selection: nil,
--- h_dollars: integer = 0,
--- h_mult: integer = 0,
--- h_size: integer = 0,
--- h_x_mult: integer = 0,
--- hands_played_at_create: integer = 0|1,
--- invis_rounds: integer = 0,
--- loyalty_remaining: unknown,
--- mult: integer = 0,
--- name: unknown,
--- order: nil,
--- p_dollars: integer = 0,
--- perma_bonus: integer = 0,
--- set: unknown,
--- t_chips: integer = 0,
--- t_mult: integer = 0,
--- to_do_poker_hand: unknown,
--- type: string = '',
--- x_mult: integer = 1,
--- yorick_discards: unknown,
 
 
 return PlayCards

--- a/custom-actions/play_cards.lua
+++ b/custom-actions/play_cards.lua
@@ -112,7 +112,6 @@ end
 
 -- id play card button: "play_button"
 function PlayCards:_execute_action(state)
-    sendDebugMessage("running PlayCards execute")
     local selected_hand = state["hand"]
 
     -- local play_button = G.buttons:get_UIE_by_ID('play_button') -- not used
@@ -122,7 +121,7 @@ function PlayCards:_execute_action(state)
 
     local highlighted_cards = {}
 
-    for pos, card in pairs(selected_hand) do
+    for _, card in pairs(selected_hand) do
         local card_id = card
         for index = 1, #hand_string, 1  do
             if card == hand_string[index] and (highlighted_cards[card_id] or 0) < selected_amount[card] then
@@ -130,10 +129,6 @@ function PlayCards:_execute_action(state)
                 highlighted_cards[card_id] = (highlighted_cards[card_id] or 0) + 1
             end
         end
-    end
-
-    for key, value in pairs(G.hand.highlighted) do
-        sendDebugMessage("key: " .. tostring(key) .. " value: " .. tostring(value))
     end
 
     -- shouldn't cause any issues with mods

--- a/custom-actions/play_cards.lua
+++ b/custom-actions/play_cards.lua
@@ -1,0 +1,281 @@
+local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
+
+local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+
+local PlayCards = setmetatable({}, { __index = NeuroAction })
+PlayCards.__index = PlayCards
+
+function PlayCards:new(actionWindow, state)
+    local obj = NeuroAction.new(self, actionWindow)
+    return obj
+end
+
+function PlayCards:_get_name()
+    return "play_cards"
+end
+
+function PlayCards:_get_description()
+    local description = "play a maximum of 5 cards with your current hand."
+
+    return description
+end
+
+function PlayCards:_get_schema()
+    return JsonUtils.wrap_schema({
+        hand = {
+			type = "array",
+            items = {
+				type = "string",
+				enum = self:_get_hand()
+			},
+		}
+    })
+end
+
+function PlayCards:_validate_action(data, state)
+    local selected_hand = data:get_object("hand")
+    selected_hand = selected_hand._data  -- get_object returns incoming data instead of the object :)
+
+    -- sendErrorMessage(selected_hand) -- issue here?
+
+    for key, value in pairs(selected_hand) do
+        sendDebugMessage("table k/v: " .. key .. " , " .. value)
+    end
+
+    if not selected_hand then
+        return ExecutionResult.failure(SDK_Strings.action_failed_missing_required_parameter("hand"))
+    end
+
+	sendInfoMessage("Length of table: " .. #selected_hand) -- TODO: selected hand is always 0 idk why
+
+    if #selected_hand == 0 then return ExecutionResult.failure("At least one card must be selected.") end
+
+    if #selected_hand > 5 then return ExecutionResult.failure("Cannot play more than 5 cards.") end
+
+	local hand = self:_get_hand() -- check hand to see if has selected more than are available
+    local selected_amount = {}
+    local hand_amount = {}
+
+    -- check if card exist
+	for _, selected_card in pairs(selected_hand) do
+        if not table.any(hand, function(hand_card)
+                return hand_card == selected_card
+            end) then
+            return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter(selected_card .. " is not in your hand."))
+        end
+    end
+
+    --TODO: dont repeate this code as much
+
+    -- add one for each card that is in the hand
+    for _, card in pairs(hand) do
+        if hand_amount[card] == nil then
+            sendDebugMessage("setting " .. card .. "to 1 on hand")
+            hand_amount[card] = 1
+        else
+            sendDebugMessage("adding 1 to " .. card .. " on hand")
+            hand_amount[card] = hand_amount[card] + 1 -- should increment for each type of card in hand
+        end
+    end
+
+    -- add one for each card that is in the selected hand
+    for _, card in pairs(selected_hand) do
+        if selected_amount[card] == nil then
+            sendDebugMessage("setting " .. card .. "to 1")
+            selected_amount[card] = 1
+        else
+            sendDebugMessage("adding 1 to " .. card)
+            selected_amount[card] = selected_amount[card] + 1 -- should increment for each type of card in hand
+        end
+    end
+
+    -- get if trying to play more cards than in hand
+    for _, card in pairs(selected_hand) do
+        if selected_amount[card] > hand_amount[card] then
+            return ExecutionResult.failure("You can only use the cards given in the hand. You tried to play more " .. card .. "'s when those do not exist")
+        else
+            sendDebugMessage("lowering " .. card .. "by 1")
+            selected_amount[card] = selected_amount[card] - 1
+        end
+    end
+
+    state["hand"] = selected_hand
+    return ExecutionResult.success()
+end
+
+-- id play card button: "play_button"
+function PlayCards:_execute_action(state)
+    sendDebugMessage("running PlayCards execute")
+    local selected_hand = state["hand"]
+
+    sendDebugMessage("G.deck" .. tostring(G.play.cards))
+    sendDebugMessage(tostring(selected_hand))
+
+    for key, value in pairs(G.hand.highlighted) do
+        sendDebugMessage("first key: " .. tostring(key) .. " value: " .. tostring(value))
+    end
+
+
+    local play_button = G.buttons:get_UIE_by_ID('play_button')
+    local hand_string = self:_get_hand()
+    local hand = G.hand.cards
+    for location, card in pairs(selected_hand) do -- TODO: find way too include position of card in hand as right now it will do card 1-5
+        for index = 1, #hand_string, 1  do
+            if card == hand_string[index] then
+                G.hand:add_to_highlighted(hand[index])
+                -- send_hand[#send_hand + 1] = hand[index]
+            end
+        end
+    end
+
+    for key, value in pairs(G.hand.highlighted) do
+        sendDebugMessage("key: " .. tostring(key) .. " value: " .. tostring(value))
+    end
+
+    -- shouldn't cause any issues with mods
+    G.FUNCS.play_cards_from_highlighted() -- try
+
+    -- couldn't get this to work and I hate ui so function call is good enough for now
+    -- play_button:click() -- play_cards_from_highlighted
+    -- G.buttons:get_UIE_by_ID('play_button'):release()
+
+	return true
+end
+
+ -- foil var localize: G.P_CENTERS.e_foil.config.extra
+local function get_edition_args(name,card_config)
+    sendDebugMessage(tprint(card_config,1,2))
+    local loc_args = {}
+    if name == "foil" then loc_args = {card_config.config.extra} end -- returns 50 as foil adds 50 chips
+    -- if name == "foil" then loc_args = {localize{type = 'name_text', key = 'e_foil', set='G.P_CENTERS.e_foil.config.extra'}} end
+    return loc_args
+end
+
+function PlayCards:_get_hand() -- G.hand.cards  G.play.cards
+	local cards = {}
+	for pos, card in ipairs(G.hand.cards) do -- Can get editions with card.edition / enhancements with card.ability / seal with card.seal
+
+        local name = card.base.name
+
+        sendDebugMessage("card edition " .. tostring(card.config))
+
+        if card.edition then
+            local key_override
+            for _, v in pairs(G.P_CENTER_POOLS.Edition) do
+                local loc_args,loc_nodes = get_edition_args(card.edition.type,G.P_CENTERS[v.key]), {} -- idk why G.P_CENTERS contains the extra's details but it works
+                sendDebugMessage("original_key: " .. tostring(v.original_key) .. " edition type: " .. tostring(card.edition.type))
+                sendDebugMessage(tprint(v,1,2))
+                sendDebugMessage("v: " .. tostring(v) .. " v type " .. type(v))
+                if v.original_key ~= card.edition.type then goto continue end
+                if v.loc_vars and type(v.loc_vars) == 'function' then
+                    -- local res = v:loc_vars() or {}
+                    loc_args = v.vars or loc_args
+                    key_override = v.key
+                    sendDebugMessage("key: " .. v.key .. " vars " .. tprint(loc_args,1,2))
+                    -- sendDebugMessage("loc_vars: " .. v:loc_vars())
+
+                    localize{type = "descriptions", set = 'Edition',key= key_override or card.key, nodes = loc_nodes, vars = loc_args}
+                    sendDebugMessage("loc_vars " .. tostring(card.loc_vars) .. " type " .. type(card.loc_vars))
+                    -- sendDebugMessage("override " .. key_override)
+
+                    sendDebugMessage("loc_args " .. tostring(loc_args[1]) .. " loc_nodes " .. tostring(loc_nodes[1]))
+
+                    local description = ""
+                    sendDebugMessage("before loc_nodes for " .. tostring(table.get_keys(loc_nodes)))
+                    for _, line in ipairs(loc_nodes) do
+                        for _, v in ipairs(line) do
+                            sendDebugMessage("Text: " .. v.config.text)
+                            description = description .. v.config.text
+                        end
+                        description = description
+                    end
+
+                    name = name .. description
+                end
+            ::continue::
+            end
+
+        -- for _, desc in pairs(G.P_CENTERS.e_foil) do
+        --     if desc.loc_vars and type(desc.loc_vars) == 'function' then
+        --         local res = desc:loc_vars() or {}
+        --         loc_args = res.vars or {}
+        --         key_override = res.key
+        --     end
+        -- end
+
+
+        --TODO: change this to get from localize like select_deck
+
+        -- if card.ability.name == "Bonus Card" then
+        --     name = name .. " Enhancement: Bonus Card: +30 chips"
+        -- elseif card.ability.name == "Mult Card" then
+        --     name = name .. " Enhancement: Bonus Card: 	+4 Mult"
+        -- end
+
+        -- if edition == nil then
+        --     goto continue
+        -- end
+
+        -- -- this should probably be changed for modding support but good enough for vanilla
+        -- if card.edition.foil then
+        --     name = name .. " edition: Foil: +50 chips when scored."
+        -- elseif card.edition.holo then
+        --     name = name .. " edition: Holographic: +10 Mult when scored."
+        -- elseif card.edition.polychrome then
+        --     name = name .. " edition: Polychrome: X1.5 Mult when scored."
+        -- elseif card.edition == nil then
+        --     name = name
+        -- end
+        -- elseif card.edition.negative then -- this is unused in vanilla (according to the wiki)
+        --     name = " edition: Negative: +1 hand size"
+
+		cards[#cards+1] = name -- this will give to neuro as "{value} of {suit}"
+        end
+    end
+    return cards
+end
+
+-- self.edition
+-- chips: integer = 50,
+-- foil: boolean = true,
+-- holo: boolean = true,
+-- mult: integer = 10,
+-- negative: boolean = true,
+-- polychrome: boolean = true,
+-- type: string = 'foil'|'holo'|'negative'|'polychrome',
+-- x_mult: number = 1.5,
+
+-- self.ability
+
+-- bonus: integer,
+-- burnt_hand: integer = 0,
+-- caino_xmult: integer = 1,
+-- consumeable: unknown,
+-- d_size: integer = 0,
+-- effect: unknown,
+-- extra: table,
+-- extra_value: integer = 0,
+-- forced_selection: nil,
+-- h_dollars: integer = 0,
+-- h_mult: integer = 0,
+-- h_size: integer = 0,
+-- h_x_mult: integer = 0,
+-- hands_played_at_create: integer = 0|1,
+-- invis_rounds: integer = 0,
+-- loyalty_remaining: unknown,
+-- mult: integer = 0,
+-- name: unknown,
+-- order: nil,
+-- p_dollars: integer = 0,
+-- perma_bonus: integer = 0,
+-- set: unknown,
+-- t_chips: integer = 0,
+-- t_mult: integer = 0,
+-- to_do_poker_hand: unknown,
+-- type: string = '',
+-- x_mult: integer = 1,
+-- yorick_discards: unknown,
+
+
+return PlayCards

--- a/get_text.lua
+++ b/get_text.lua
@@ -218,7 +218,6 @@ function getText:get_hand_enhancements()
     return cards
 end
 
-
 local function get_seals_args(name)
     local loc_args = {}
     if name == "Gold" then loc_args = {"gold_seal"}

--- a/get_text.lua
+++ b/get_text.lua
@@ -52,6 +52,7 @@ function getText:get_back_descriptions()
             	key_override = res.key
             end
 
+            sendDebugMessage("key_override: " .. tostring(key_override) .. " back.key: " .. tostring(back.key))
             localize{type = 'descriptions', key = key_override or back.key, set = 'Back', nodes = loc_nodes, vars = loc_args}
                         
             local description = ""
@@ -106,4 +107,197 @@ function getText:get_stake_names(keys, allStakes)
     return stakes
 end
 
+local function get_edition_args(name,card_config)
+    local loc_args = {}
+    if name == "foil" then loc_args = {card_config.config.extra} -- returns 50 as foil adds 50 chips
+    elseif name == "holo" then loc_args = {card_config.config.extra}
+    elseif name == "polychrome" then loc_args = {card_config.config.extra} end
+    return loc_args
+end
+
+function getText:get_hand_editions() -- G.hand.cards  G.play.cards
+	local cards = {}
+	for pos, card in ipairs(G.hand.cards) do -- Can get editions with card.edition / enhancements with card.ability / seal with card.seal
+
+        local name = card.base.name
+
+        sendDebugMessage("card edition " .. tostring(card.config))
+
+        if card.edition then
+            local key_override
+            for _, v in pairs(G.P_CENTER_POOLS.Edition) do
+                local loc_args,loc_nodes = get_edition_args(card.edition.type,G.P_CENTERS[v.key]), {} -- idk why G.P_CENTERS contains the extra's details but it works
+                sendDebugMessage("original_key: " .. tostring(v.original_key) .. " edition type: " .. tostring(card.edition.type))
+                sendDebugMessage(tprint(v,1,2))
+                sendDebugMessage("v: " .. tostring(v) .. " v type " .. type(v))
+                if v.original_key ~= card.edition.type then goto continue end -- go next loop if not the same as card
+                if v.loc_vars and type(v.loc_vars) == 'function' then
+                    -- local res = v:loc_vars() or {} -- this causes crashes idk why, works without it though
+                    loc_args = v.vars or loc_args
+                    key_override = v.key
+
+                    localize{type = "descriptions", set = 'Edition',key= key_override or card.key, nodes = loc_nodes, vars = loc_args}
+                    sendDebugMessage("loc_vars " .. tostring(card.loc_vars) .. " type " .. type(card.loc_vars))
+
+                    local description = ""
+                    for _, line in ipairs(loc_nodes) do
+                        for _, word in ipairs(line) do
+                            sendDebugMessage("Text: " .. word.config.text)
+                            description = description .. word.config.text
+                        end
+                    end
+
+                    name = name .. description
+                end
+            ::continue::
+            end
+        end
+		cards[#cards+1] = name -- this will give to neuro as "{value} of {suit}"
+    end
+    return cards
+end
+
+local function get_enhancements_args(name,card_config)
+    sendDebugMessage("card config: " .. tprint(card_config,1,2))
+    sendDebugMessage("card config config: " .. tprint(card_config.config,1,2))
+    sendDebugMessage("card config mult: " .. tostring(card_config.config.mult) .. " name " .. name)
+    local loc_args = {}
+    if name == "Bonus Card" then loc_args = {card_config.config.bonus}
+    elseif name == "Mult Card" then loc_args = {card_config.config.mult}
+    elseif name == "Wild Card" then loc_args = {card_config.config.extra} --  localize
+    elseif name == "Glass Card" then loc_args = {card_config.config.Xmult, card_config.config.extra} -- 2x 1 in 4 chance to break (this is sent as 4)
+    elseif name == "Steel Card" then loc_args = {card_config.config.h_x_mult} -- 1.5 while in hand
+    elseif name == "Stone Card" then loc_args = {card_config.config.bonus} -- is always 50
+    elseif name == "Gold Card" then loc_args = {card_config.config.h_dollars} -- three in hand
+    elseif name == "Lucky Card" then loc_args = {card_config.config.p_dollars,card_config.config.mult} end -- 1 in 5 chance for +20 mult and 1 in 15 for $20 (these are both sent as 20)
+    return loc_args
+end
+
+-- these are stuff like Bonus card and mult Card
+function getText:get_hand_enhancements()
+    local cards = {}
+	for pos, card in ipairs(G.hand.cards) do
+
+        local name = card.base.name
+
+        sendDebugMessage("card config table: " .. tprint(card.config,1,2))
+
+        if card.ability.effect then
+            local key_override
+            for _, v in pairs(G.P_CENTER_POOLS.Enhanced) do
+                local loc_args,loc_nodes = get_enhancements_args(card.ability.effect,G.P_CENTERS[v.key]), {}
+                if v.key ~= card.config.center_key then goto continue end -- go next loop if not the same as card
+                    key_override = v.key or card.config.center_key
+
+                    localize{type = "descriptions", set = 'Enhanced',key= key_override or card.config.center_key, nodes = loc_nodes, vars = loc_args}  -- TODO: doesnt get + in mult card idk why
+
+                    local description = ""
+                    for _, line in ipairs(loc_nodes) do
+                        for _, word in ipairs(line) do
+                            sendDebugMessage("Text: " .. word.config.text)
+                            description = description .. word.config.text
+                        end
+                    end
+
+                    name = name .. description
+            ::continue::
+            end
+        end
+		cards[#cards+1] = name -- this will give to neuro as "{value} of {suit}"
+    end
+    return cards
+end
+
+
+local function get_seals_args(name,card_config)
+    sendDebugMessage("card config: " .. tprint(card_config,1,2))
+    local loc_args = {}
+    if name == "Gold Seal" then loc_args = {card_config.config.bonus}
+    elseif name == "Red Seal" then loc_args = {card_config.config.mult}
+    elseif name == "Blue Seal" then loc_args = {card_config.config.bonus}
+    elseif name == "Purple Seal" then loc_args = {card_config} end
+end
+
+-- these are stuff like Bonus card and mult Card
+function getText:get_hand_seals()
+    local cards = {}
+
+    -- for key, value in pairs(SMODS.Seal) do
+    --     sendDebugMessage("center pools key: " .. tostring(key) .. " value: " .. tprint(value,1,2))
+    -- end
+
+    for key, value in pairs(G.P_CENTER_POOLS.Seal) do
+        sendDebugMessage("center pools key: " .. tostring(key) .. " value: " .. tprint(value,1,2))
+    end
+
+	for pos, card in ipairs(G.hand.cards) do
+
+        local name = card.base.name
+
+        -- for key, value in pairs(G.P_CENTERS) do
+        --     sendDebugMessage("key: " .. tostring(key) .. " value: " .. tprint(value,1,2))
+        -- end
+
+
+        if card.ability.seal then
+            -- sendDebugMessage("seal: " .. SMODS.Seal.)
+
+            sendDebugMessage("card abilities: " .. tprint(card.ability))
+            sendDebugMessage("card config table: " .. tprint(card.ability.seal,1,2)) -- tprint(card.seal,1,2)
+        end
+
+        -- if card.seal then
+        --     local key_override
+        --     for _, v in pairs(G.P_CENTER_POOLS.Seal) do
+        --         sendDebugMessage("Seals: " .. tprint(v,5,5))
+        --         local loc_args,loc_nodes = get_seals_args(card.seal,G.P_CENTERS[v.key]), {}
+        --         if v.key ~= card.config.center_key then goto continue end -- go next loop if not the same as card
+        --             key_override = v.key or card.config.center_key
+
+                    -- localize{type = "descriptions", set = 'Other',key= key_override or card.config.center_key, nodes = loc_nodes, vars = loc_args}  -- TODO: doesnt get + in mult card idk why
+
+        --             local description = ""
+        --             for _, line in ipairs(loc_nodes) do
+        --                 for _, word in ipairs(line) do
+        --                     sendDebugMessage("Text: " .. word.config.text)
+        --                     description = description .. word.config.text
+        --                 end
+        --             end
+
+        --             name = name .. description
+        --     ::continue::
+        --     end
+        -- end
+		-- cards[#cards+1] = name -- this will give to neuro as "{value} of {suit}"
+    end
+    return cards
+end
+
+
 return getText
+
+--  _saved_d_u= "true",
+--        original_key= "Gold",
+--        registered= "true",
+--        badge_colour= table: 0x03fb6688        {
+--           [1] = 0.91764705882353,
+--           [2] = 0.75294117647059,
+--           [3] = 0.34509803921569,
+--           [4] = 1,
+--         },
+--        _discovered_unlocked_overwritten= "true",
+--        order= 3,
+--        _d= "false",
+--        set= "Seal",
+--        taken_ownership= "true",
+--        discovered= "false",
+--        prefix_config= table: 0x0432d800        {
+--         },
+--        generate_ui= "function: 0x0319b368",
+--        key= "Gold",
+--        pos= table: 0x04c42998        {
+--           y= 0,
+--           x= 2,
+--         },
+--        atlas= "centers",
+--        is_loc_modified= "true",

--- a/get_text.lua
+++ b/get_text.lua
@@ -107,60 +107,68 @@ function getText:get_stake_names(keys, allStakes)
     return stakes
 end
 
+function getText:get_hand_names()
+    local cards = {}
+    for pos, card in ipairs(G.hand.cards) do
+
+
+        local name = card.base.name
+
+		cards[#cards+1] = name
+	end
+	return cards
+end
+
+
 local function get_edition_args(name,card_config)
     local loc_args = {}
-    if name == "foil" then loc_args = {card_config.config.extra} -- returns 50 as foil adds 50 chips
+    if name == "foil" then loc_args = {card_config.config.extra}
     elseif name == "holo" then loc_args = {card_config.config.extra}
     elseif name == "polychrome" then loc_args = {card_config.config.extra} end
     return loc_args
 end
 
-function getText:get_hand_editions() -- G.hand.cards  G.play.cards
+function getText:get_hand_editions()
 	local cards = {}
-	for pos, card in ipairs(G.hand.cards) do -- Can get editions with card.edition / enhancements with card.ability / seal with card.seal
+	for _, card in ipairs(G.hand.cards) do
 
-        local name = card.base.name
-
-        sendDebugMessage("card edition " .. tostring(card.config))
+        local edition_desc = ""
 
         if card.edition then
             local key_override
             for _, v in pairs(G.P_CENTER_POOLS.Edition) do
-                local loc_args,loc_nodes = get_edition_args(card.edition.type,G.P_CENTERS[v.key]), {} -- idk why G.P_CENTERS contains the extra's details but it works
-                sendDebugMessage("original_key: " .. tostring(v.original_key) .. " edition type: " .. tostring(card.edition.type))
-                sendDebugMessage(tprint(v,1,2))
-                sendDebugMessage("v: " .. tostring(v) .. " v type " .. type(v))
-                if v.original_key ~= card.edition.type then goto continue end -- go next loop if not the same as card
+                local loc_args,loc_nodes = get_edition_args(card.edition.type,G.P_CENTERS[v.key]), {}
+                if v.key ~= card.edition.key then goto continue end -- go next loop if not the same as card
                 if v.loc_vars and type(v.loc_vars) == 'function' then
-                    -- local res = v:loc_vars() or {} -- this causes crashes idk why, works without it though
-                    loc_args = v.vars or loc_args
-                    key_override = v.key
+                    local res = v:loc_vars() or {}
+                    loc_args = res.vars or loc_args
+                end
+                key_override = v.key
 
-                    localize{type = "descriptions", set = 'Edition',key= key_override or card.key, nodes = loc_nodes, vars = loc_args}
-                    sendDebugMessage("loc_vars " .. tostring(card.loc_vars) .. " type " .. type(card.loc_vars))
+                localize{type = "descriptions", set = 'Edition',key= key_override or card.key, nodes = loc_nodes, vars = loc_args}
 
-                    local description = ""
-                    for _, line in ipairs(loc_nodes) do
-                        for _, word in ipairs(line) do
-                            sendDebugMessage("Text: " .. word.config.text)
+                local description = " Cards edition: "
+                for _, line in ipairs(loc_nodes) do
+                    for _, word in ipairs(line) do
+                        if word.nodes ~= nil then
+                            description = description .. word.nodes[1].config.text
+                        else
                             description = description .. word.config.text
                         end
+                        description = description .. " "
                     end
-
-                    name = name .. description
                 end
+
+                edition_desc = description
             ::continue::
             end
         end
-		cards[#cards+1] = name
+		cards[#cards+1] = edition_desc
     end
     return cards
 end
 
 local function get_enhancements_args(name,card_config)
-    sendDebugMessage("card config: " .. tprint(card_config,1,2))
-    sendDebugMessage("card config config: " .. tprint(card_config.config,1,2))
-    sendDebugMessage("card config mult: " .. tostring(card_config.config.mult) .. " name " .. name)
     local loc_args = {}
     if name == "Bonus Card" then loc_args = {card_config.config.bonus}
     elseif name == "Mult Card" then loc_args = {card_config.config.mult}
@@ -173,50 +181,45 @@ local function get_enhancements_args(name,card_config)
     return loc_args
 end
 
--- these are stuff like Bonus card and mult Card
 function getText:get_hand_enhancements()
     local cards = {}
 	for pos, card in ipairs(G.hand.cards) do
 
-        local name = card.base.name
+        local enhancement_desc = ""
 
-        sendDebugMessage("card config table: " .. tprint(card.config,1,2))
-
-        if card.ability.effect then
+        if not card.ability.effect then
             local key_override
             for _, v in pairs(G.P_CENTER_POOLS.Enhanced) do
                 local loc_args,loc_nodes = get_enhancements_args(card.ability.effect,G.P_CENTERS[v.key]), {}
-                if v.key ~= card.seal then goto continue end -- go next loop if not the same as card
-                    if v.loc_txt and type(v.loc_vars) == 'function' then -- not tested probably works though
-                        local res = v:loc_vars() or {}
-                        sendDebugMessage("res value: " .. tprint(res,1,2))
-                        loc_args = res.vars or {}
-                        key_override = v.key
+                if v.key ~= card.config.center.name then goto continue end -- go next loop if not the same as card
+                if v.loc_txt and type(v.loc_vars) == 'function' then
+                    local res = v:loc_vars(nil,card) or {} -- makes twins card work and glorp still works so I think its fine
+                    loc_args = res.vars or {}
+                end
+                key_override = v.key
+
+                localize{type = "descriptions", set = 'Enhanced',key= key_override or card.config.original_key, nodes = loc_nodes, vars = loc_args}  -- TODO: doesnt get + in mult card idk why
+
+                local description = " Cards enhancement: "
+                for _, line in ipairs(loc_nodes) do
+                    for _, word in ipairs(line) do
+                        if not word.config.text then break end -- removes table that contains stuff for setting up UI
+                        sendDebugMessage("word: " .. tostring(word))
+                        description = description .. word.config.text
                     end
-                    key_override = v.key
+                end
 
-                    localize{type = "descriptions", set = 'Enhanced',key= key_override or card.config.center_key, nodes = loc_nodes, vars = loc_args}  -- TODO: doesnt get + in mult card idk why
-
-                    local description = ""
-                    for _, line in ipairs(loc_nodes) do
-                        for _, word in ipairs(line) do
-                            sendDebugMessage("Text: " .. word.config.text)
-                            description = description .. word.config.text
-                        end
-                    end
-
-                    name = name .. description
+                enhancement_desc = description
             ::continue::
             end
         end
-		cards[#cards+1] = name
+		cards[#cards+1] = enhancement_desc
     end
     return cards
 end
 
 
 local function get_seals_args(name)
-    sendDebugMessage("name: " .. name)
     local loc_args = {}
     if name == "Gold" then loc_args = {"gold_seal"}
     elseif name == "Red" then loc_args = {"red_seal"}
@@ -225,64 +228,48 @@ local function get_seals_args(name)
     return loc_args
 end
 
--- these are stuff like Bonus card and mult Card
 function getText:get_hand_seals()
     local cards = {}
 
-    local seals = {"gold_seal","red_seal","blue_seal","purple_seal"} -- bad but I can't find a way to get them :'(
+    local seals = {"gold_seal","red_seal","blue_seal","purple_seal"} -- bad but I'm a bit too lazy to find another way and it works
 
 	for pos, card in ipairs(G.hand.cards) do
 
-        local name = card.base.name
+        local seal_desc = ""
 
         if card.ability.seal then
             local key_override = nil
             for _, v in pairs(G.P_CENTER_POOLS.Seal) do
-                sendDebugMessage("v key: " .. v.key)
-                -- if v.key == "seel_blu" then
-                --     test_args = v
-                --     sendDebugMessage("setting test args")
-                -- end
-                sendDebugMessage(tprint(v,1,2))
-                local loc_args,loc_nodes,loc_set = get_seals_args(card.seal), {}, 'Other'
-                if v.key ~= card.seal then goto continue end -- go next loop if not the same as card
-                    if v.loc_txt and type(v.loc_vars) == 'function' then -- this is for modded seals
-                        local res = v:loc_vars() or {}
-                        sendDebugMessage("res value: " .. tprint(res,1,2))
-                        loc_args = res.vars or {}
-                        key_override = v.key
-                        loc_set = v.set
-                    else
-                        loc_args = get_seals_args(card.seal) -- this is for vanilla seals
-                        key_override = loc_args[1]
-                        loc_args = {}
-                        loc_set = 'Other' -- we need to do this because v.set would be Set which doesn't exist
-                    end
+                local loc_args,loc_nodes = get_seals_args(card.seal), {}
+                if v.key ~= card.seal then goto continue end
+                if v.loc_txt and type(v.loc_vars) == 'function' then
+                    local res = v:loc_vars() or {}
+                    loc_args = res.vars or {}
+                    key_override = v.key .. '_seal' -- Smods does this however doesn't mention it in any documentation :)
+                else -- vanilla seal
+                    key_override = loc_args[1]
+                    loc_args = {}
+                end
 
-                    -- key_override = v.key -- modded seals dont use loc_vars for key
-                    -- key_override = test_args.key
+                localize{type = 'descriptions', set = "Other" or v.set, key= key_override or v.key, nodes = loc_nodes, vars = loc_args}
 
-                    -- loc_args = test_args.config
-                    -- local args_set = test_args.set -- "Other" on vanilla
-                    sendDebugMessage("loc_args: " .. tprint(loc_args,1,2) .. " Set: " .. loc_set .. " key: " .. tostring(key_override))
-                    -- key_override is nil ???
-                    localize{type = 'descriptions', set = loc_set or v.set, key= key_override or v.key, nodes = loc_nodes, vars = loc_args} --TODO: doesnt get for example modded
-
-                    sendDebugMessage("loc_nodes: " .. tprint(loc_nodes,1,2))
-
-                    local description = ""
-                    for _, line in ipairs(loc_nodes) do
-                        for _, word in ipairs(line) do
-                            sendDebugMessage("Text: " .. word.config.text)
+                local description = " Cards seal: "
+                for _, line in ipairs(loc_nodes) do
+                    for _, word in ipairs(line) do
+                        if word.nodes ~= nil then
+                            description = description .. word.nodes[1].config.text
+                        else
                             description = description .. word.config.text
                         end
+                        description = description .. " "
                     end
+                end
 
-                    name = name .. description
+                seal_desc = description
             ::continue::
             end
         end
-		cards[#cards+1] = name
+		cards[#cards+1] = seal_desc
     end
     return cards
 end

--- a/hook.lua
+++ b/hook.lua
@@ -76,9 +76,7 @@ local function play_card(delay)
         trigger = "after",
         delay = delay,
         func = function()
-            sendDebugMessage("start action event")
             local window = ActionWindow:new()
-            -- window:set_force(0.0, "Pick a deck", "", false)
             window:add_action(PlayCards:new(window, nil))
             window:register()
             return true
@@ -160,7 +158,6 @@ local function hook_start_run()
     function Game:start_run(args)
         start_run(self,args)
 
-        sendDebugMessage("call first event")
         G.E_MANAGER:add_event(Event({
             trigger = "after",
             delay = 4,
@@ -180,14 +177,14 @@ local function hook_start_run()
             end
         }))
 
-        sendDebugMessage("after first event")
     end
     return true
 end
 
+-- call play_card after selecting first bind
 SMODS.Keybind{
 	key = 'test_cards',
-	key_pressed = 'c', -- other key(s) that need to be held
+	key_pressed = 'c',
 
     action = function(self)
         G.E_MANAGER:add_event(Event({

--- a/hook.lua
+++ b/hook.lua
@@ -1,6 +1,7 @@
 local GameHooks = ModCache.load("game-sdk/game_hooks.lua")
 local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
 local SelectDeck = ModCache.load("custom-actions/select_deck.lua")
+local PlayCards = ModCache.load("custom-actions/play_cards.lua")
 
 local Hook = {}
 Hook.__index = Hook
@@ -63,6 +64,22 @@ local function select_deck(delay)
             local window = ActionWindow:new()
             window:set_force(0.0, "Pick a deck", "", false)
             window:add_action(SelectDeck:new(window, nil))
+            window:register()
+            return true
+        end
+    }
+    ))
+end
+
+local function play_card(delay)
+    G.E_MANAGER:add_event(Event({
+        trigger = "after",
+        delay = delay,
+        func = function()
+            sendDebugMessage("start action event")
+            local window = ActionWindow:new()
+            -- window:set_force(0.0, "Pick a deck", "", false)
+            window:add_action(PlayCards:new(window, nil))
             window:register()
             return true
         end
@@ -138,6 +155,62 @@ local function hook_main_menu()
     end
 end
 
+local function hook_start_run()
+    local start_run = Game.start_run
+    function Game:start_run(args)
+        start_run(self,args)
+
+        sendDebugMessage("call first event")
+        G.E_MANAGER:add_event(Event({
+            trigger = "after",
+            delay = 4,
+            blocking = false,
+            func = function ()
+                G.E_MANAGER:add_event(Event({
+                trigger = "after",
+                delay = 4,
+                blocking = false,
+                func = function ()
+                    sendDebugMessage("start second event")
+                    play_card(8)
+                    return true
+                end
+                }))
+            return true
+            end
+        }))
+
+        sendDebugMessage("after first event")
+    end
+    return true
+end
+
+SMODS.Keybind{
+	key = 'test_cards',
+	key_pressed = 'c', -- other key(s) that need to be held
+
+    action = function(self)
+        G.E_MANAGER:add_event(Event({
+            trigger = "after",
+            delay = 0,
+            blocking = false,
+            func = function ()
+                G.E_MANAGER:add_event(Event({
+                trigger = "after",
+                delay = 0,
+                blocking = false,
+                func = function ()
+                    sendDebugMessage("start second event")
+                    play_card(2)
+                    return true
+                end
+                }))
+            return true
+            end
+        }))
+    end,
+}
+
 
 function Hook:hook_game()
     if not neuro_profile or neuro_profile < 1 or neuro_profile > 3 then
@@ -154,6 +227,8 @@ function Hook:hook_game()
     end
 
     hook_main_menu()
+
+    hook_start_run()
 end
 
 return Hook

--- a/hook.lua
+++ b/hook.lua
@@ -172,7 +172,7 @@ local function hook_start_run()
                 blocking = false,
                 func = function ()
                     sendDebugMessage("start second event")
-                    play_card(8)
+                    play_card(12)
                     return true
                 end
                 }))


### PR DESCRIPTION
Add action for playing cards, including the current card modifications on a card should also work with card modifications and suites added by mods. The only hooks for registering the action are when the "c" key is pressed or a few seconds after a run is started.