### PR TITLE
Disconnect websocket on crash and optional restart

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,10 @@ return {
     -- Delay in seconds before attempting to reconnect
     ["RECONNECT_DELAY"] = 5,
 
+    -- If true, the game will restart if there is a crash after smods is loaded.
+    -- This should be set to false if you need to see logs without checking their respective folder.
+    ["CAN_RESTART_ON_CRASH"] = true,
+
     -- The profile Neuro should use. If save data exists in this slot, we are going to assume it belongs to Neuro and
     -- continue the game from there if there's an active run. If there's no save data, we will create a new
     -- profile in this slot.

--- a/game-sdk/websocket/websocket_connection.lua
+++ b/game-sdk/websocket/websocket_connection.lua
@@ -144,4 +144,5 @@ function WebsocketConnection:_send_internal(data)
 end
 
 WebsocketConnection._instance = WebsocketConnection:new()
+WEBSOCKET = WebsocketConnection._instance -- This is used in restart_crash.toml
 return WebsocketConnection._instance

--- a/hook.lua
+++ b/hook.lua
@@ -17,6 +17,8 @@ Hook.__index = Hook
 
 local should_unlock = NeuroConfig.UNLOCK_ALL
 
+G.can_restart = NeuroConfig.CAN_RESTART_ON_CRASH
+
 local function load_profile(delay)
     G.E_MANAGER:add_event(Event({
         trigger = "after",

--- a/lovely/restart_crash.toml
+++ b/lovely/restart_crash.toml
@@ -9,11 +9,13 @@ pattern = '''
 if love.timer then
     love.timer.sleep(0.1)
 end
-''' # This is added by smods and can only be found in dumps
+''' # This is added by smods and can only be found in dumps made by lovely
 position = "before"
 payload = '''
 WEBSOCKET._client:close()
-SMODS.restart_game()
+if G.can_restart then
+    SMODS.restart_game()
+end
 '''
 match_indent = true
 times = 1

--- a/lovely/restart_crash.toml
+++ b/lovely/restart_crash.toml
@@ -5,10 +5,15 @@ priority = -20
 [[patches]]
 [patches.pattern]
 target = "main.lua"
-pattern = "if love.timer then"
-position = "after"
+pattern = '''
+if love.timer then
+    love.timer.sleep(0.1)
+end
+''' # This is added by smods and can only be found in dumps
+position = "before"
 payload = '''
-love.event.push("keypressed","r")
+WEBSOCKET._client:close()
+SMODS.restart_game()
 '''
 match_indent = true
 times = 1

--- a/lovely/restart_crash.toml
+++ b/lovely/restart_crash.toml
@@ -1,0 +1,14 @@
+[manifest]
+version = "1.0.0"
+priority = -20
+
+[[patches]]
+[patches.pattern]
+target = "main.lua"
+pattern = "if love.timer then"
+position = "after"
+payload = '''
+love.event.push("keypressed","r")
+'''
+match_indent = true
+times = 1

--- a/playing_run.lua
+++ b/playing_run.lua
@@ -183,6 +183,14 @@ function PlayingRun:hook_round_eval()
     end
 end
 
+SMODS.Keybind{
+    key_pressed = 'c',
+    action = function (self)
+        sendDebugMessage("running keybind")
+        G.deck[1]:click()
+    end
+}
+
 function PlayingRun:register_play_actions(delay,hook)
     G.E_MANAGER:add_event(Event({
         trigger = "after",


### PR DESCRIPTION
This adds support for disconnecting the websocket connection when the game crashes. As well as adding the option to automatically restart the game on crash, this is mainly meant for if Neuro plays the game with a mod like Neuratro which is much more likely to crash than the original game.

The latter can be disabled in the config.lua file, the description for this option may need to be rewritten as it is a bit wordy.  however I do think in the current state it does get the point across