### PR TITLE
add sending poker hands as context

### DIFF
--- a/playing_run.lua
+++ b/playing_run.lua
@@ -118,6 +118,8 @@ function PlayingRun:hook_new_round()
         else
             Context.send("You do not have any consumeables as of right now.")
         end
+
+        Context.send(table.concat(RunContext:hand_type_information(),"\n"))
     end
 end
 

--- a/run_context.lua
+++ b/run_context.lua
@@ -72,4 +72,25 @@ function RunContext:hand_pack_booster()
     end
 end
 
+function RunContext:hand_type_information()
+    local context_hands = {}
+    for name, hand in pairs(G.GAME.hands) do
+        if hand.visible then
+            local description = name .. ": " .. "level: " .. tostring(hand.level) .. " chips: " .. tostring(hand.chips) .. " mult: " .. tostring(hand.mult) .. " description: "
+
+            local loc_nodes = G.localization.misc.poker_hand_descriptions[SMODS.PokerHand.obj_table[name].original_key]
+            local temp_desc = ""
+            for index, desc in ipairs(loc_nodes) do
+                if index <= #loc_nodes - 1 then
+                    desc = desc .. " "
+                end
+                temp_desc = temp_desc .. desc
+            end
+            description = description .. temp_desc
+            context_hands[#context_hands+1] = description
+        end
+    end
+    return context_hands
+end
+
 return RunContext


### PR DESCRIPTION
Adds sending poker hands as context, This is sent at the start of every new blind. 

In run_context.lua we get localization directly instead of localize{} as PokerHands can not have loc_vars (or it is not shown they can in the smods [documentation](https://github.com/Steamodded/smods/wiki/SMODS.PokerHand)) and due to that I am pretty sure localize{} cannot get the description.