### PR TITLE
Fix localization lookup tables for 1/x chances

### DIFF
--- a/card_loc.lua
+++ b/card_loc.lua
@@ -44,7 +44,9 @@ Tarot_Loc = {
 		return {card.config.center.config.max_highlighted,"Glass Card"}
 	end,
 	c_hermit = {"extra"},
-	c_wheel_of_fortune = {"extra"},
+	c_wheel_of_fortune = function(card)
+		return {G.GAME.probabilities.normal, card.config.center.config.extra}
+	end,
 	c_strength = function(card)
 		return {card.config.center.config.max_highlighted,"1"}
 	end,

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -10,10 +10,14 @@ Enhancement_Loc = {
 	m_bonus = {"bonus"},
 	m_mult = {"mult"},
 	m_wild = {},
-	m_glass = {"Xmult", "extra"},
+	m_glass = function(card)
+		return {card.config.Xmult, G.GAME.probabilities.normal, card.config.extra}
+	end,
 	m_stone = {"bonus"},
 	m_gold = {"h_dollars"},
-	m_lucky = {"mult","p_dollars"},
+	m_lucky = function(card)
+        return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15}
+    end,
 	m_steel = {"h_x_mult"}
 }
 

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -16,7 +16,7 @@ Enhancement_Loc = {
 	m_stone = {"bonus"},
 	m_gold = {"h_dollars"},
 	m_lucky = function(card)
-        return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15}
+        return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15, G.GAME.probabilities.normal}
     end,
 	m_steel = function(card)
 		return {card.config.extra.xmult}

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -18,7 +18,9 @@ Enhancement_Loc = {
 	m_lucky = function(card)
         return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15}
     end,
-	m_steel = {"h_x_mult"}
+	m_steel = function(card)
+		return {card.config.extra.xmult}
+	end
 }
 
 Seal_Loc = {


### PR DESCRIPTION
The localization tables for wheel of fortune, glass cards and lucky cards did not contain G.GAME.probabilities.normal to show the 1/x chance they had. G.GAME.probabilities.normal is normally 1 but gets set to 2 by Oops! All 6s. 

There is still a bug with lucky cards causing the game to instantly crash though