### PR TITLE
Context rewrite

### DIFF
--- a/card_loc.lua
+++ b/card_loc.lua
@@ -44,7 +44,9 @@ Tarot_Loc = {
 		return {card.config.center.config.max_highlighted,"Glass Card"}
 	end,
 	c_hermit = {"extra"},
-	c_wheel_of_fortune = {"extra"},
+	c_wheel_of_fortune = function(card)
+		return {G.GAME.probabilities.normal, card.config.center.config.extra}
+	end,
 	c_strength = function(card)
 		return {card.config.center.config.max_highlighted,"1"}
 	end,

--- a/config.lua
+++ b/config.lua
@@ -5,10 +5,6 @@ return {
     -- Delay in seconds before attempting to reconnect
     ["RECONNECT_DELAY"] = 5,
 
-    -- If true, the game will restart if there is a crash after smods is loaded.
-    -- This should be set to false if you need to see logs without checking their respective folder.
-    ["CAN_RESTART_ON_CRASH"] = true,
-
     -- The profile Neuro should use. If save data exists in this slot, we are going to assume it belongs to Neuro and
     -- continue the game from there if there's an active run. If there's no save data, we will create a new
     -- profile in this slot.
@@ -16,9 +12,6 @@ return {
 
     -- If true, Neuro will have all decks, jokers, vouchers, etc unlocked
     ["UNLOCK_ALL"] = true,
-
-    -- If true, Neuro will be allowed to continue runs. If false, Neuro will only be allowed to start new runs.
-    ["ALLOW_CONTINUE"] = true,
 
     -- List of allowed decks for Neuro to use. I don't think Neuro should use any other deck as they're a bit
     -- complicated, but you can make an argument for some like Checkered or Plasma. When starting a new game, Neuro will

--- a/config.lua
+++ b/config.lua
@@ -10,6 +10,10 @@ return {
     -- profile in this slot.
     ["PROFILE_SLOT"] = 3,
 
+    -- If true, the game will restart if there is a crash after smods is loaded.
+    -- This should be set to false if you need to see logs without checking their respective folder.
+    ["CAN_RESTART_ON_CRASH"] = true,
+
     -- If true, Neuro will have all decks, jokers, vouchers, etc unlocked
     ["UNLOCK_ALL"] = true,
 

--- a/custom-actions/deck_type.lua
+++ b/custom-actions/deck_type.lua
@@ -18,7 +18,9 @@ function DeckInfo:_get_name()
 end
 
 function DeckInfo:_get_description()
-    return "Get information about your deck, you can use this to plan your next moves."
+    return "Get information about what suits or ranks are currently in your deck. " ..
+	"Use this to see what cards are still left in your deck and can be drawn, " ..
+	"or to check what your deck currently looks like when planning a build."
 end
 
 local function schema_options()

--- a/custom-actions/get_poker_hand_info.lua
+++ b/custom-actions/get_poker_hand_info.lua
@@ -18,7 +18,7 @@ function PokerHandInfo:_get_name()
 end
 
 function PokerHandInfo:_get_description()
-    return "Get the current information relating to the poker-hands available."
+    return "Gets the level and stats for every poker hand."
 end
 
 function PokerHandInfo:_get_schema()

--- a/custom-actions/joker_interaction.lua
+++ b/custom-actions/joker_interaction.lua
@@ -46,10 +46,10 @@ function JokerInteraction:_get_schema()
     local hand_length = RunHelper:get_hand_length(G.jokers.cards)
 
     return JsonUtils.wrap_schema({
-        card_action = {
+        joker_action = {
             enum = joker_action_options()
         },
-        cards_index = {
+        jokers_index = {
             type = "array",
             items = {
                 type = "integer",
@@ -60,8 +60,8 @@ function JokerInteraction:_get_schema()
 end
 
 function JokerInteraction:_validate_action(data, state)
-    local selected_action = data:get_string("card_action")
-    local selected_hand_index = data:get_object("cards_index")
+    local selected_action = data:get_string("joker_action")
+    local selected_hand_index = data:get_object("jokers_index")
     selected_hand_index = selected_hand_index._data
 
     if RunHelper:check_for_duplicates(selected_hand_index) == false then

--- a/custom-actions/pick_hand_pack_cards.lua
+++ b/custom-actions/pick_hand_pack_cards.lua
@@ -45,13 +45,14 @@ function PickHandPackCards:_get_name()
 end
 
 function PickHandPackCards:_get_description()
-    local description = string.format("Pick cards from this pack, you can pick a max of " ..
+    local description = string.format("Pick a consumable to use from this pack, you can pick a max of " ..
         SMODS.OPENED_BOOSTER.config.center.config.choose
-        .. " cards "
+        .. " consumables "
         .. "out of the " ..
         SMODS.OPENED_BOOSTER.config.center.config.extra ..
-        " available. You should pick the cards you want one at a time." ..
-        " When defining the card's index the first card will be 1.")
+        " available. Some consumables require you to select cards in hand to use. " .. 
+        "Use pack_card_index to specify what consumable you are using and cards_index to specify what cards it is being used on. " ..
+        "When defining the card's index the first card will be 1.")
 
     return description
 end

--- a/custom-actions/pick_hand_pack_cards.lua
+++ b/custom-actions/pick_hand_pack_cards.lua
@@ -50,7 +50,7 @@ function PickHandPackCards:new(actionWindow, state)
 end
 
 function PickHandPackCards:_get_name()
-    return "pick_hand_cards"
+    return "pick_pack_cards"
 end
 
 function PickHandPackCards:_get_description()
@@ -60,7 +60,7 @@ function PickHandPackCards:_get_description()
         .. "out of the " ..
         SMODS.OPENED_BOOSTER.config.center.config.extra ..
         " available. Some consumables require you to select cards in hand to use. " .. 
-        "Use pack_card_index to specify what consumable you are using and cards_index to specify what cards it is being used on. " ..
+        "Use pack_card_index to specify what consumable you are using and hand_cards_index to specify what cards it is being used on. " ..
         "When defining the card's index the first card will be 1.")
 
     return description
@@ -71,7 +71,7 @@ function PickHandPackCards:_get_schema()
     local pack_hand_length = RunHelper:get_hand_length(G.pack_cards.cards)
 
     return JsonUtils.wrap_schema({
-        cards_index = {
+        hand_cards_index = {
             type = "array",
             items = {
                 type = "integer",
@@ -85,7 +85,7 @@ function PickHandPackCards:_get_schema()
 end
 
 function PickHandPackCards:_validate_action(data, state)
-    local selected_hand_index = data:get_object("cards_index")
+    local selected_hand_index = data:get_object("hand_cards_index")
     local selected_pack_card = data._data["pack_card_index"]
     selected_hand_index = selected_hand_index._data
 

--- a/custom-actions/pick_pack_card.lua
+++ b/custom-actions/pick_pack_card.lua
@@ -90,7 +90,7 @@ function PickCards:_validate_action(data, state)
     end
 
     state["cards_index"] = selected_hand_index
-	return ExecutionResult.success("Taking the " .. selected_card.config.center.name .. " card.")
+	return ExecutionResult.success("Taking the " .. selected_card.base.name)
 end
 
 function PickCards:_execute_action(state)

--- a/custom-actions/pick_pack_card.lua
+++ b/custom-actions/pick_pack_card.lua
@@ -90,7 +90,7 @@ function PickCards:_validate_action(data, state)
     end
 
     state["cards_index"] = selected_hand_index
-	return ExecutionResult.success("Taking the " .. selected_card.base.name)
+	return ExecutionResult.success("Taking the " .. (selected_card.base.name or selected_card.config.center.name))
 end
 
 function PickCards:_execute_action(state)

--- a/custom-actions/play_blind.lua
+++ b/custom-actions/play_blind.lua
@@ -16,7 +16,7 @@ function PlayBlind:_get_name()
 end
 
 function PlayBlind:_get_description()
-    return "Start the selected blind"
+    return "Start the selected blind."
 end
 
 function PlayBlind:_get_schema()

--- a/custom-actions/shop-actions/buy_shop_booster.lua
+++ b/custom-actions/shop-actions/buy_shop_booster.lua
@@ -17,7 +17,7 @@ function BuyBooster:_get_name()
 end
 
 function BuyBooster:_get_description()
-    return "This will buy a booster pack."
+    return "Buy a booster pack in shop. These contain a certain number of cards that you can choose from."
 end
 
 function BuyBooster:_get_schema()

--- a/custom-actions/shop-actions/buy_shop_booster.lua
+++ b/custom-actions/shop-actions/buy_shop_booster.lua
@@ -44,7 +44,7 @@ function BuyBooster:_validate_action(data, state)
     end
 
 	state["booster_index"] = selected_index
-    return ExecutionResult.success("opening " .. booster.ability.name)
+    return ExecutionResult.success("Opening " .. booster.ability.name)
 end
 
 function BuyBooster:_execute_action(state)

--- a/custom-actions/shop-actions/buy_shop_card.lua
+++ b/custom-actions/shop-actions/buy_shop_card.lua
@@ -18,7 +18,8 @@ function BuyShopCard:_get_name()
 end
 
 function BuyShopCard:_get_description()
-    return "Buy a card from the shop, this will be from the card category"
+    return "Buy a card from the shop. These will generally be either a jokers or a consumable. "
+    .. "Some consumables can be immediately used, or can be held onto if you have inventory space."
 end
 
 local function card_actions()

--- a/custom-actions/shop-actions/buy_shop_card.lua
+++ b/custom-actions/shop-actions/buy_shop_card.lua
@@ -80,7 +80,7 @@ function BuyShopCard:_validate_action(data, state)
 
     state["selected_action"] = selected_action
     state["selected_index"] = selected_index
-    return ExecutionResult.success()
+    return ExecutionResult.success("Buying " .. (selected_action == "buy and use" and "and using " or "") .. card.config.center.name)
 end
 
 function BuyShopCard:_execute_action(state)

--- a/custom-actions/shop-actions/buy_shop_voucher.lua
+++ b/custom-actions/shop-actions/buy_shop_voucher.lua
@@ -18,7 +18,7 @@ function BuyVoucher:_get_name()
 end
 
 function BuyVoucher:_get_description()
-    return "This will buy the voucher available in the shop."
+    return "This will buy a voucher available in the shop."
 end
 
 function BuyVoucher:_get_schema()

--- a/custom-actions/shop-actions/buy_shop_voucher.lua
+++ b/custom-actions/shop-actions/buy_shop_voucher.lua
@@ -35,14 +35,14 @@ end
 
 function BuyVoucher:_validate_action(data, state)
     local selected_index = data._data["voucher_index"] or 1
-	local voucher = G.shop_vouchers.cards[1]
+	local voucher = G.shop_vouchers.cards[selected_index]
 
     if ((G.GAME.dollars-G.GAME.bankrupt_at) - voucher.children.price.parent.cost < 0) then
         return ExecutionResult.failure("You do not have the money to buy the voucher.")
     end
 
     if #G.shop_vouchers.cards <= 1 then
-        return ExecutionResult.success()
+        return ExecutionResult.success("Bought the " .. voucher.ability.name .. " voucher")
     end
 
     local valid_voucher_indices = RunHelper:get_hand_length(G.shop_vouchers.cards)
@@ -51,7 +51,7 @@ function BuyVoucher:_validate_action(data, state)
     end
 
     state["voucher_index"] = selected_index
-    return ExecutionResult.success()
+    return ExecutionResult.success("Bought the " .. voucher.ability.name .. " voucher")
 end
 
 function BuyVoucher:_execute_action(state)

--- a/custom-actions/shop-actions/exit_shop.lua
+++ b/custom-actions/shop-actions/exit_shop.lua
@@ -20,7 +20,7 @@ function ExitShop:_get_name()
 end
 
 function ExitShop:_get_description()
-    return "This will exit the shop and take you to picking the next blind."
+    return "This will exit the shop and take you to blind selection. Do whatever shopping and prep you need before doing this!"
 end
 
 function ExitShop:_get_schema()

--- a/custom-actions/shop-actions/reroll_shop.lua
+++ b/custom-actions/shop-actions/reroll_shop.lua
@@ -26,9 +26,9 @@ end
 
 function RerollShop:_validate_action(data, state)
     if G.GAME.current_round.free_rerolls >= 1 then
-        return ExecutionResult.success("You have skipped this round using a free reroll, you have " .. tostring(G.GAME.current_round.free_rerolls) .. " free rerolls left.")
+        return ExecutionResult.success("You rerolled the shop using free reroll, you have " .. tostring(G.GAME.current_round.free_rerolls) .. " free rerolls left.")
     else
-        return ExecutionResult.success("You have skipped this round using your money, it cost: " .. tostring(G.GAME.current_round.reroll_cost))
+        return ExecutionResult.success("You rerolled the shop using your money, it cost $" .. tostring(G.GAME.current_round.reroll_cost))
     end
 end
 

--- a/custom-actions/shop-actions/reroll_shop.lua
+++ b/custom-actions/shop-actions/reroll_shop.lua
@@ -17,7 +17,7 @@ function RerollShop:_get_name()
 end
 
 function RerollShop:_get_description()
-    return "Reroll the shop, this will add new cards to the shop if you have the money or if you have free rerolls."
+    return "Reroll the shop. This only rerolls cards, not booster packs or vouchers."
 end
 
 function RerollShop:_get_schema()

--- a/custom-actions/skip_blind.lua
+++ b/custom-actions/skip_blind.lua
@@ -16,7 +16,7 @@ function SkipBlind:_get_name()
 end
 
 function SkipBlind:_get_description()
-    return "Skip the selected blind"
+    return "Skips the selected blind, gaining a tag as a reward."
 end
 
 function SkipBlind:_get_schema()

--- a/custom-actions/skip_blind.lua
+++ b/custom-actions/skip_blind.lua
@@ -4,6 +4,7 @@ local PlayBlind = ModCache.load("custom-actions/play_blind.lua")
 local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
 local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
 local RerollBlind = ModCache.load("custom-actions/reroll_blind.lua")
+local GetText = ModCache.load("get_text.lua")
 local SkipBlind = setmetatable({}, { __index = NeuroAction })
 SkipBlind.__index = SkipBlind
 
@@ -48,7 +49,7 @@ function SkipBlind:_execute_action(state)
             if G.STATE ~= G.STATES.BLIND_SELECT then return false end
             local window = ActionWindow:new()
             window:set_force(0.0, "Choose to select, skip or reroll the currently selected blind",
-                "It is time for you to select a blind.")
+                GetText:generate_blind_descriptions())
             window:add_action(PlayBlind:new(window))
             if G.GAME.blind_on_deck ~= "Boss" then
                 window:add_action(SkipBlind:new(window))

--- a/custom-actions/skip_pack.lua
+++ b/custom-actions/skip_pack.lua
@@ -18,7 +18,7 @@ function SkipPack:_get_name()
 end
 
 function SkipPack:_get_description()
-    local description = "Skip this pack and take no more cards from it."
+    local description = "Close the pack early and take no additional cards from it."
 
     return description
 end

--- a/custom-actions/use_consumables.lua
+++ b/custom-actions/use_consumables.lua
@@ -34,8 +34,11 @@ function UseConsumable:_get_description()
     end
 
     local description = string.format(
-        "Use a consumable in your consumable hand. This can either be planet, spectral or tarot cards," ..
-        " Each type will affect the game in it's own unique way" ..
+        "Use or sell a consumable in your consumable hand. This will either be planet, spectral or tarot cards." ..
+        " Each card has a unqiue effect that will alter your run and help you build your deck." ..
+        " Some consumeables need to be used on cards in hand." ..
+        " Specify the consumable to use with consumable_index and use cards_index to specify what cards in hand to use it on" ..
+        " Here is a list of all consumeables you have: " ..
         table.concat(cards, "", 1, #cards))
 
     return description

--- a/custom-actions/use_consumables.lua
+++ b/custom-actions/use_consumables.lua
@@ -83,8 +83,8 @@ function UseConsumable:_validate_action(data, state)
         end) then
         return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("consumable_index"))
     end
-
-    local card_config = G.consumeables.cards[tonumber(selected_consumable)].config.center.config
+    local card = G.consumeables.cards[tonumber(selected_consumable)]
+    local card_config = card.config.center.config
 
     if not selected_consumable then
         return ExecutionResult.failure("issue with selected_consumable")
@@ -138,7 +138,10 @@ function UseConsumable:_validate_action(data, state)
     state["card_action"] = selected_action
     state["consumable_index"] = selected_consumable
     state["cards_index"] = selected_hand_index
-    return ExecutionResult.success()
+    if selected_action == "Use" then
+        return ExecutionResult.success("Using " .. card.config.center.name)
+    end
+    return ExecutionResult.success("Selling the " .. card.config.center.name .. " for " .. card.sell_cost)
 end
 
 function UseConsumable:_execute_action(state)

--- a/custom-actions/use_hand_cards.lua
+++ b/custom-actions/use_hand_cards.lua
@@ -22,8 +22,8 @@ end
 function UseHandCards:_get_description()
     local description = string.format("Either play or discard a maximum of " ..
         G.hand.config.highlighted_limit .. " cards with your current hand." ..
-        "The cards will be ordered by the position they are located in your hand from left to right." ..
-        "When defining the card's index the first card will be 1, you should send these in the same order as you send the cards")
+        "The cards will be ordered by the position they are located in your hand from left to right," ..
+        " with the left-most card being index 1. Specify cards in cards_index in the order you wish for them to be used.")
 
     return description
 end

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -27,8 +27,9 @@ function GetRunText:get_celestial_names(card_hand)
     return cards
 end
 
-function GetRunText:get_celestial_details(card_hand,add_cost)
+function GetRunText:get_celestial_details(card_hand,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local cards = {}
 
 	for pos, card in ipairs(card_hand) do
@@ -51,8 +52,7 @@ function GetRunText:get_celestial_details(card_hand,add_cost)
                     }
 
                 localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args}
-
-                local description = "\n" .. name .. ": "
+                local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
                         if word.nodes ~= nil then
@@ -93,8 +93,9 @@ function GetRunText:get_joker_names(card_hand)
     return cards
 end
 
-function GetRunText:get_joker_details(card_hand,add_cost)
+function GetRunText:get_joker_details(card_hand,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local cards = {}
 
 	for pos, card in ipairs(card_hand) do
@@ -121,7 +122,10 @@ function GetRunText:get_joker_details(card_hand,add_cost)
 
                 localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args}
 
-                local description = "\n" .. name .. ": "
+                local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
+                if name == "Misprint" then
+                    description = description .. "Gives a random amount of mult from +0 to +23 (inclusive)"
+                end
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
                         if word.nodes ~= nil then
@@ -165,8 +169,9 @@ function GetRunText:get_spectral_names(card_hand)
     return cards
 end
 
-function GetRunText:get_spectral_details(card_hand,add_cost)
+function GetRunText:get_spectral_details(card_hand,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local cards = {}
 
 	for pos, card in ipairs(card_hand) do
@@ -194,7 +199,7 @@ function GetRunText:get_spectral_details(card_hand,add_cost)
 
                 localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set, nodes = loc_nodes, vars = loc_args}
 
-                local description = "\n" .. name .. ": "
+                local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
                         if word.nodes ~= nil then
@@ -238,18 +243,19 @@ function GetRunText:get_tarot_names(card_hand)
     return cards
 end
 
-function GetRunText:get_tarot_details(card_hand,add_cost)
+function GetRunText:get_tarot_details(card_hand,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local cards = {}
 
 	for pos, card in ipairs(card_hand) do
 		local tarot_desc = ""
 
-        if card.ability.set == 'Tarot' then
+        if card.ability.set == 'Tarot' or card.ability.name == "The Soul" then
             local key_override = nil
             for card_id, g_card in pairs(G.P_CENTERS) do
                 if g_card.name ~= card.ability.name then goto continue end
-                local loc_lookup = Tarot_Loc[card_id]
+                local loc_lookup = Tarot_Loc[card_id] or Spectral_Loc[card_id]
                 local loc_args = {}
                 local loc_nodes = {}
                 local name = card.ability.name
@@ -267,7 +273,7 @@ function GetRunText:get_tarot_details(card_hand,add_cost)
 
                 localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args}
 
-                local description = "\n" .. name .. ": "
+                local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
                         if word.nodes ~= nil then
@@ -293,8 +299,9 @@ function GetRunText:get_tarot_details(card_hand,add_cost)
     return cards
 end
 
-function GetRunText:get_booster_details(boosters,add_cost)
+function GetRunText:get_booster_details(boosters,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local shop_boosters = {}
 
 	for pos, booster in ipairs(boosters) do
@@ -321,7 +328,7 @@ function GetRunText:get_booster_details(boosters,add_cost)
 
                 localize{type = 'descriptions', key = key_override, set = "Other" or booster.ability.set, nodes = loc_nodes, vars = loc_args}
 
-                local description = "\n" .. name .. ": "
+                local description = "\n" .. (count and ("- " .. #shop_boosters + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
                         if word.nodes ~= nil then
@@ -347,8 +354,9 @@ function GetRunText:get_booster_details(boosters,add_cost)
     return shop_boosters
 end
 
-function GetRunText:get_voucher_details(voucher_table,add_cost)
+function GetRunText:get_voucher_details(voucher_table,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local vouchers = {}
 
 	for pos, voucher in ipairs(voucher_table) do
@@ -374,7 +382,7 @@ function GetRunText:get_voucher_details(voucher_table,add_cost)
 
                 localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args}
 
-                local description = "\n" .. name .. ": "
+                local description = "\n" .. (count and ("- " .. #vouchers + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
                         if word.nodes ~= nil then
@@ -400,32 +408,34 @@ function GetRunText:get_voucher_details(voucher_table,add_cost)
     return vouchers
 end
 
-function GetRunText:get_shop_text(card_table,add_cost)
+function GetRunText:get_shop_text(card_table,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local card = card_table[1]
 
     if card.ability.set == "Booster" then
-        return GetRunText:get_booster_details(card_table,add_cost)
+        return GetRunText:get_booster_details(card_table,add_cost,count)
     elseif card.ability.set == "Voucher" then
-        return GetRunText:get_voucher_details(card_table,add_cost)
+        return GetRunText:get_voucher_details(card_table,add_cost,count)
     elseif card.ability.set == "Joker" then
-        return GetRunText:get_joker_details(card_table,add_cost)
+        return GetRunText:get_joker_details(card_table,add_cost,count)
     end
 end
 
-function GetRunText:get_consumeables_text(cards,add_cost)
+function GetRunText:get_consumeables_text(cards,add_cost,count)
     add_cost = add_cost or false
+    count = count or false
     local cards_details = {}
 
     for index, card in ipairs(cards) do
         if card.ability.set == "Planet" then
-            cards_details[#cards_details+1] = GetRunText:get_celestial_details({card},add_cost)[1]
+            cards_details[#cards_details+1] = (count and ("\n" .. "- " .. #cards_details + 1 .. ": ") or "") .. string.sub(GetRunText:get_celestial_details({card},add_cost)[1], 2) 
         elseif card.ability.set == "Tarot" then
-            cards_details[#cards_details+1] = GetRunText:get_tarot_details({card},add_cost)[1]
+            cards_details[#cards_details+1] = (count and ("\n" .. "- " .. #cards_details + 1 .. ": ")) .. string.sub(GetRunText:get_tarot_details({card},add_cost)[1], 2)
         elseif card.ability.set == "Spectral" then
-            cards_details[#cards_details+1] = GetRunText:get_spectral_details({card},add_cost)[1]
+            cards_details[#cards_details+1] = (count and ("\n" .. "- " .. #cards_details + 1 .. ": ")) .. string.sub(GetRunText:get_spectral_details({card},add_cost)[1], 2)
         elseif card.ability.set == "Joker" then
-            cards_details[#cards_details+1] = GetRunText:get_joker_details({card},add_cost)[1]
+            cards_details[#cards_details+1] = (count and ("\n" .. "- " .. #cards_details + 1 .. ": ")) .. string.sub(GetRunText:get_joker_details({card},add_cost)[1], 2)
         end
     end
 

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -690,9 +690,9 @@ function GetRunText:get_current_hand_modifiers(cards_table)
     local editions = table.table_to_string(self:get_hand_editions(cards_table))
     local seals = table.table_to_string(self:get_hand_seals(cards_table))
 
-    local enhancements_string = "- card enhancements: " .. enhancements
-    local editions_string = "- card editions: " .. editions
-    local seals_string = "- card seals: " .. seals
+    local enhancements_string = "- Enhancements: " .. enhancements
+    local editions_string = "- Editions: " .. editions
+    local seals_string = "- Seals: " .. seals
 
     if enhancements == "" or enhancements == nil then
         enhancements_string = ""

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -35,8 +35,9 @@ function GetRunText:get_celestial_details(card_hand,add_cost,count)
 	for pos, card in ipairs(card_hand) do
 		sendDebugMessage("start for loop")
 		local planet_desc = ""
-
-        if card.ability.set == "Planet" then
+        if card.ability.name == "Black Hole" then
+            planet_desc = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. "Black Hole: Upgrades all poker hands by 1 level"
+        elseif card.ability.set == "Planet" then
             for _, v in pairs(G.P_CENTER_POOLS.Planet) do
                 local loc_args,loc_nodes = {}, {}
                 local name = card.ability.name
@@ -50,7 +51,6 @@ function GetRunText:get_celestial_details(card_hand,add_cost,count)
                     SMODS.PokerHand.obj_table[v.config.hand_type].level,localize(v.config.hand_type, 'poker_hands'), SMODS.PokerHand.obj_table[v.config.hand_type].l_mult, SMODS.PokerHand.obj_table[v.config.hand_type].l_chips,
                     colours = {(SMODS.PokerHand.obj_table[v.config.hand_type].level==1 and G.C.UI.TEXT_DARK or G.C.HAND_LEVELS[math.min(7, SMODS.PokerHand.obj_table[v.config.hand_type].level)])}
                     }
-
                 localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args}
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do

--- a/hook.lua
+++ b/hook.lua
@@ -283,11 +283,13 @@ function Hook:hook_game()
     Context.send("Welcome to Balatro! Balatro is a roguelike deck builder based around poker. " ..
         "In each round, or blind, you can play or discard a limited number of hands consisting of up to 5 cards. " ..
         "Each blind has a score requirement you have to reach, otherwise you will game over. " ..
-        "Each poker hand has a base chips and mult that determines how much the hand will score. " ..
+        "Each poker hand has a base chips and multiplier that determines how much the hand will score. " ..
         "Then, every card played has it's value added to the chips (11 for Aces, 10 for King/Queen/Jack, then 10-2 for the rest). " ..
         "Only cards that directly count to the poker hand are counted. For example, if you play a two pair with an extra 5th card, " ..
         "the 5th card will not be counted. You may also get cards with modifiers like granting extra chips or mult when scored. " ..
         "The main component of Balatro deckbuilding are jokers. Jokers grant a variety of effects, from extra chips or mult to money or even consumables. " ..
+        "The order in which you play cards and sort your jokers matter, as effects activate from left to right. " ..
+        "For example, any effect that multiplies your total mult should be after any effects that increase your total mult by a flat amount. " ..
         "With the right setup of jokers, even a single high card can score more than a straight royal flush. Good luck!")
 end
 

--- a/hook.lua
+++ b/hook.lua
@@ -279,6 +279,16 @@ function Hook:hook_game()
     PlayingRun:hook_evaluate_play()
 
     hook_blind_select()
+
+    Context.send("Welcome to Balatro! Balatro is a roguelike deck builder based around poker. " ..
+        "In each round, or blind, you can play or discard a limited number of hands consisting of up to 5 cards. " ..
+        "Each blind has a score requirement you have to reach, otherwise you will game over. " ..
+        "Each poker hand has a base chips and mult that determines how much the hand will score. " ..
+        "Then, every card played has it's value added to the chips (11 for Aces, 10 for King/Queen/Jack, then 10-2 for the rest). " ..
+        "Only cards that directly count to the poker hand are counted. For example, if you play a two pair with an extra 5th card, " ..
+        "the 5th card will not be counted. You may also get cards with modifiers like granting extra chips or mult when scored. " ..
+        "The main component of Balatro deckbuilding are jokers. Jokers grant a variety of effects, from extra chips or mult to money or even consumables. " ..
+        "With the right setup of jokers, even a single high card can score more than a straight royal flush. Good luck!")
 end
 
 return Hook

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -18,9 +18,7 @@ Enhancement_Loc = {
 	m_lucky = function(card)
         return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15, G.GAME.probabilities.normal}
     end,
-	m_steel = function(card)
-		return {card.config.extra.xmult}
-	end
+	m_steel = {"h_x_mult"}
 }
 
 Seal_Loc = {

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -10,10 +10,14 @@ Enhancement_Loc = {
 	m_bonus = {"bonus"},
 	m_mult = {"mult"},
 	m_wild = {},
-	m_glass = {"Xmult", "extra"},
+	m_glass = function(card)
+		return {card.config.Xmult, G.GAME.probabilities.normal, card.config.extra}
+	end,
 	m_stone = {"bonus"},
 	m_gold = {"h_dollars"},
-	m_lucky = {"mult","p_dollars"},
+	m_lucky = function(card)
+        return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15}
+    end,
 	m_steel = {"h_x_mult"}
 }
 

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -16,7 +16,7 @@ Enhancement_Loc = {
 	m_stone = {"bonus"},
 	m_gold = {"h_dollars"},
 	m_lucky = function(card)
-        return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15}
+        return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15, G.GAME.probabilities.normal}
     end,
 	m_steel = function(card)
 		return {card.config.extra.xmult}

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -18,7 +18,9 @@ Enhancement_Loc = {
 	m_lucky = function(card)
         return {G.GAME.probabilities.normal, card.config.mult, 5, card.config.p_dollars, 15}
     end,
-	m_steel = {"h_x_mult"}
+	m_steel = function(card)
+		return {card.config.extra.xmult}
+	end
 }
 
 Seal_Loc = {

--- a/playing_run.lua
+++ b/playing_run.lua
@@ -289,7 +289,7 @@ function PlayingRun:register_store_actions(delay,hook)
             if (G.GAME.dollars-G.GAME.bankrupt_at) - G.GAME.current_round.reroll_cost < 0 and G.GAME.current_round.free_rerolls < 1 then
             else
                 actions[#actions+1] = RerollShop
-                state = state .. "\n Rerolling the shop costs: $" .. G.GAME.current_round.reroll_cost .. " You have" .. G.GAME.current_round.free_rerolls .. " free rerolls."
+                state = state .. "\n Rerolling the shop costs: $" .. G.GAME.current_round.reroll_cost .. " You have " .. G.GAME.current_round.free_rerolls .. " free rerolls."
             end
             if #G.shop_jokers.cards > 0 then
                 actions[#actions+1] = BuyShopCard

--- a/playing_run.lua
+++ b/playing_run.lua
@@ -289,19 +289,19 @@ function PlayingRun:register_store_actions(delay,hook)
             if (G.GAME.dollars-G.GAME.bankrupt_at) - G.GAME.current_round.reroll_cost < 0 and G.GAME.current_round.free_rerolls < 1 then
             else
                 actions[#actions+1] = RerollShop
-                state = state .. "\n Rerolling the shop costs: $" .. G.GAME.current_round.reroll_cost .. " You have " .. G.GAME.current_round.free_rerolls .. " free rerolls."
+                state = state .. "\nRerolling the shop costs $" .. G.GAME.current_round.reroll_cost .. ". You have " .. G.GAME.current_round.free_rerolls .. " free rerolls."
             end
             if #G.shop_jokers.cards > 0 then
                 actions[#actions+1] = BuyShopCard
-                state = state .. "\n These are the cards in the shop right now: " .. table.table_to_string(GetRunText:get_consumeables_text(G.shop_jokers.cards,true))
+                state = state .. "\nThese are the cards in the shop right now: " .. table.table_to_string(GetRunText:get_consumeables_text(G.shop_jokers.cards,true, true))
             end
             if #G.shop_booster.cards > 0 then
                 actions[#actions+1] = BuyShopBooster
-                state = state .. "\n These are the booster packs in the shop: " .. table.table_to_string(GetRunText:get_shop_text(G.shop_booster.cards,true))
+                state = state .. "\nThese are the booster packs in the shop: " .. table.table_to_string(GetRunText:get_shop_text(G.shop_booster.cards,true, true))
             end
             if #G.shop_vouchers.cards > 0 then
                 actions[#actions+1] = BuyShopVoucher
-                state = state .. "\n This is the voucher in the shop: " .. table.table_to_string(GetRunText:get_shop_text(G.shop_vouchers.cards,true))
+                state = state .. "\nThis is the voucher in the shop: " .. table.table_to_string(GetRunText:get_shop_text(G.shop_vouchers.cards,true, true))
             end
 
             actions[#actions+1] = DeckTypes

--- a/run_context.lua
+++ b/run_context.lua
@@ -6,14 +6,14 @@ local RunContext = {}
 function RunContext:no_hand_booster()
 	if G.pack_cards == nil or G.pack_cards.cards == nil or G.pack_cards.cards == {} then return end
     if SMODS.OPENED_BOOSTER.config.center.kind == "Buffoon" or G.pack_cards.cards[1].ability.set == "Joker" then
-        local hand = table.table_to_string(GetRunText:get_joker_details(G.pack_cards.cards))
+        local hand = table.table_to_string(GetRunText:get_joker_details(G.pack_cards.cards, false, true))
 
         return string.format("These are the jokers in this pack: " ..
         hand .. "\n" ..
         "You can only select a joker if you have the inventory space for it. " ..
         "Jokers are the main deckbuilding component of Balatro and can provide a variety of effects that help in scoring or provide extra money or consumables.")
     elseif SMODS.OPENED_BOOSTER.config.center.kind == "Celestial" or G.pack_cards.cards[1].ability.set == "Celestial" then
-        local hand = table.table_to_string(GetRunText:get_celestial_details(G.pack_cards.cards))
+        local hand = table.table_to_string(GetRunText:get_celestial_details(G.pack_cards.cards, false, true))
 
         return string.format("These are the planet cards in this pack: " ..
         hand .. "\n" ..
@@ -64,13 +64,13 @@ function RunContext:hand_pack_booster()
 
     if G.pack_cards == nil or G.pack_cards.cards == nil or G.pack_cards.cards == {} then return end
     if SMODS.OPENED_BOOSTER.config.center.kind == "Spectral" then
-        local pack_hand = table.table_to_string(GetRunText:get_spectral_details(G.pack_cards.cards))
+        local pack_hand = table.table_to_string(GetRunText:get_spectral_details(G.pack_cards.cards, false, true))
         return string.format("These are the consumables in this pack: " .. pack_hand), hand_string
     elseif SMODS.OPENED_BOOSTER.config.center.kind == "Arcana" then
-        local pack_hand = table.table_to_string(GetRunText:get_tarot_details(G.pack_cards.cards))
+        local pack_hand = table.table_to_string(GetRunText:get_tarot_details(G.pack_cards.cards, false, true))
         return string.format("These are the consumables in this pack: " .. pack_hand), hand_string
     else -- modded packs that dont contain contain a default set or if there is something I forgot
-        local pack_hand = table.table_to_string(GetRunText:get_hand_details(G.pack_cards.cards))
+        local pack_hand = table.table_to_string(GetRunText:get_hand_details(G.pack_cards.cards, false, true))
         return string.format("These are the consumables in this pack: " .. pack_hand), hand_string
     end
 end

--- a/run_context.lua
+++ b/run_context.lua
@@ -8,20 +8,20 @@ function RunContext:no_hand_booster()
     if SMODS.OPENED_BOOSTER.config.center.kind == "Buffoon" or G.pack_cards.cards[1].ability.set == "Joker" then
         local hand = table.table_to_string(GetRunText:get_joker_details(G.pack_cards.cards))
 
-        return string.format("This is the hand of cards that are in this pack: " ..
+        return string.format("These are the jokers in this pack: " ..
         hand .. "\n" ..
-        "These cards will give passive bonuses after each hand played, these range from increasing the chips" ..
-        " increasing the mult of a hand or giving money or consumables after certain actions.")
+        "You can only select a joker if you have the inventory space for it. " ..
+        "Jokers are the main deckbuilding component of Balatro and can provide a variety of effects that help in scoring or provide extra money or consumables.")
     elseif SMODS.OPENED_BOOSTER.config.center.kind == "Celestial" or G.pack_cards.cards[1].ability.set == "Celestial" then
         local hand = table.table_to_string(GetRunText:get_celestial_details(G.pack_cards.cards))
 
-        return string.format("This is the hand of cards that are in this pack: " ..
+        return string.format("These are the planet cards in this pack: " ..
         hand .. "\n" ..
-        "These cards will level up a poker hand and improve the scoring that you will receive for playing them.")
+        "Planet cards level up the base chips and mult of a specific poker hand.")
     elseif SMODS.OPENED_BOOSTER.config.center.kind == "Standard" or G.pack_cards.cards[1].ability.set == "Base" then
         local hand, enhancements, editions, seals = table.table_to_string(GetRunText:get_card_modifiers(G.pack_cards.cards)),GetRunText:get_current_hand_modifiers(G.pack_cards.cards)
 
-        local return_string = "This is the hand of cards that are in this pack: " .. hand .. "\n" .. "\n"
+        local return_string = "These are the playing cards in this pack: " .. hand .. "\n" .. "\n"
         if enhancements ~= "" or editions ~= "" or seals ~= "" then
             return_string = return_string .. string.format("These are the card modifiers that are on the cards right now," ..
             " there can only be one edition,enhancement and seal on each card: \n" ..
@@ -65,13 +65,13 @@ function RunContext:hand_pack_booster()
     if G.pack_cards == nil or G.pack_cards.cards == nil or G.pack_cards.cards == {} then return end
     if SMODS.OPENED_BOOSTER.config.center.kind == "Spectral" then
         local pack_hand = table.table_to_string(GetRunText:get_spectral_details(G.pack_cards.cards))
-        return string.format("This is the hand of cards that are in this pack: " .. pack_hand), hand_string
+        return string.format("These are the consumables in this pack: " .. pack_hand), hand_string
     elseif SMODS.OPENED_BOOSTER.config.center.kind == "Arcana" then
         local pack_hand = table.table_to_string(GetRunText:get_tarot_details(G.pack_cards.cards))
-        return string.format("This is the hand of cards that are in this pack: " .. pack_hand), hand_string
+        return string.format("These are the consumables in this pack: " .. pack_hand), hand_string
     else -- modded packs that dont contain contain a default set or if there is something I forgot
         local pack_hand = table.table_to_string(GetRunText:get_hand_details(G.pack_cards.cards))
-        return string.format("This is the hand of cards that are in this pack: " .. pack_hand), hand_string
+        return string.format("These are the consumables in this pack: " .. pack_hand), hand_string
     end
 end
 

--- a/run_functions_helper.lua
+++ b/run_functions_helper.lua
@@ -53,21 +53,21 @@ function RunHelper:get_query_string(state)
     local state_string = ""
     if state == G.STATES.SELECTING_HAND or state == G.STATES.PLAY_TAROT then
         local enhancements, editions, seals = GetRunText:get_current_hand_modifiers(G.hand.cards)
-        query_string = "It is now time for you to pick cards to either play or discard, if you want to sell or move your jokers or use consumeables you should do that now."
+        query_string = "It's time to pick cards in your hand to play or discard. You can also use consumables re-order jokers, or sell either jokers or consumables."
         if enhancements ~= "" or editions ~= "" or seals ~= "" then -- probably dont need this if there are no card modifiers
-            state_string = "These are what the card's modifiers do, there can only be one edition,enhancement and seal on each card: \n" .. enhancements .. "\n" .. editions .."\n" .. seals
+            state_string = "These are what the modifiers on your cards in hand do. A card can have one edition, enhancement or seal on it: \n" .. enhancements .. "\n" .. editions .."\n" .. seals
         end
-        state_string = state_string .. "These are the current cards in your hand, their modifiers and if they are debuffed: " .. table.table_to_string(GetRunText:get_card_modifiers(G.hand.cards,G.GAME.blind.boss))
+        state_string = state_string .. "These are the cards in your hand, their modifiers and if they are debuffed. Debuffed cards do not get scored: " .. table.table_to_string(GetRunText:get_card_modifiers(G.hand.cards,G.GAME.blind.boss))
     elseif state == G.STATES.SHOP then
-        query_string = "You are now in the shop! you can either use your money to, buy items to help you in this run or reroll to see new items."
+        query_string = "You are now in the shop! You can use your money to buy cards, booster packs or vouchers to help your run. You can also use consumables and sell jokers/consumables you no longer need. When done shopping, you can exit the shop to blind selection."
         state_string = "You currently have $" .. tostring(G.GAME.dollars) .. " to spend."
     elseif state == 999 then
         if SMODS.OPENED_BOOSTER.config.center.draw_hand then
-            query_string = "You have opened a booster and now you need to pick a card from it, you may need to also select cards from your hand."
+            query_string = "You have opened a booster pack containing consumables and can now pick a consumable to immediately use from it. You can also select cards from your hand to use if the consumable needs it."
             local pack_cards, hand_cards = RunContext:hand_pack_booster()
             state_string = pack_cards .. "\n" .. hand_cards
         else
-            query_string = "You have opened a booster and now you need to pick a card from it."
+            query_string = "You have opened a booster pack containing cards and can now select cards to keep from it."
             state_string = RunContext:no_hand_booster()
         end
     end

--- a/run_functions_helper.lua
+++ b/run_functions_helper.lua
@@ -57,7 +57,12 @@ function RunHelper:get_query_string(state)
         if enhancements ~= "" or editions ~= "" or seals ~= "" then -- probably dont need this if there are no card modifiers
             state_string = "These are what the modifiers on your cards in hand do. A card can have one edition, enhancement or seal on it: \n" .. enhancements .. "\n" .. editions .."\n" .. seals
         end
-        state_string = state_string .. "These are the cards in your hand, their modifiers and if they are debuffed. Debuffed cards do not get scored: " .. table.table_to_string(GetRunText:get_card_modifiers(G.hand.cards,G.GAME.blind.boss))
+        if G.GAME.blind.boss then
+            state_string = state_string .. "These are the cards in your hand, their modifiers and if they are debuffed. Debuffed cards do not get scored: "
+        else
+            state_string = state_string .. "These are the cards in your hand and their modifiers: "
+        end
+        state_string = state_string .. table.table_to_string(GetRunText:get_card_modifiers(G.hand.cards,G.GAME.blind.boss))
     elseif state == G.STATES.SHOP then
         query_string = "You are now in the shop! You can use your money to buy cards, booster packs or vouchers to help your run. You can also use consumables and sell jokers/consumables you no longer need. When done shopping, you can exit the shop to blind selection."
         state_string = "You currently have $" .. tostring(G.GAME.dollars) .. " to spend."


### PR DESCRIPTION
Mainly just changes to the context messages, but has a few other related changes to context messages sent to Neuro:

- Adds a one time context message sent on game start to Neuro briefly explaining how the game works
- Almost every context message has been re-worded in some way 
- Added index numbers to cards in packs and in shops to hopefully be easier for Neuro 
- Fixes a bug with Steel cards crashing the game due to incorrect localization
- Fixes a bug with PickCards ActionResult sending the card edition instead of card name (it worked for jokers, just not playing cards) 
- Changes the PickHandPackCards action name to pick_pack_cards, and renames the cards_index parameter in the schema to hand_cards_index 