### PR TITLE
Fixes for negative cards and other localization/context issues

### DIFF
--- a/custom-actions/pick_pack_card.lua
+++ b/custom-actions/pick_pack_card.lua
@@ -82,12 +82,8 @@ function PickCards:_validate_action(data, state)
     end
 
     local selected_card = G.pack_cards.cards[selected_hand_index]
-    if selected_card.ability.set == "Joker" and #G.jokers.cards >= G.jokers.config.card_limit then
+    if selected_card.ability.set == "Joker" and #G.jokers.cards >= G.jokers.config.card_limit and (selected_card.edition == nil or selected_card.edition.key ~= "e_negative") then
         return ExecutionResult.failure("You cannot add anymore jokers to your hand, you should either sell some or skip this pack")
-    end
-
-    if selected_card.ability.set == "Planet" and #G.consumeables.cards >= G.consumeables.config.card_limit then
-        return ExecutionResult.failure("You cannot add anymore consumables to your hand, you could either sell or use some of those cards or you could skip this pack")
     end
 
     state["cards_index"] = selected_hand_index

--- a/custom-actions/shop-actions/buy_shop_booster.lua
+++ b/custom-actions/shop-actions/buy_shop_booster.lua
@@ -38,13 +38,16 @@ function BuyBooster:_validate_action(data, state)
     end
 
 	local booster = G.shop_booster.cards[selected_index]
-
+    local name = booster.ability.name
+    if booster.config.center.mod and booster.config.center.loc_txt then
+        name = booster.config.center.loc_txt.name
+    end
     if ((G.GAME.dollars-G.GAME.bankrupt_at) - booster.children.price.parent.cost < 0) then
         return ExecutionResult.failure("You do not have the money to buy this pack")
     end
 
 	state["booster_index"] = selected_index
-    return ExecutionResult.success("Opening " .. booster.ability.name)
+    return ExecutionResult.success("Opening " .. name)
 end
 
 function BuyBooster:_execute_action(state)

--- a/custom-actions/shop-actions/buy_shop_card.lua
+++ b/custom-actions/shop-actions/buy_shop_card.lua
@@ -66,13 +66,18 @@ function BuyShopCard:_validate_action(data, state)
         return ExecutionResult.failure("You can only buy this card")
     end
 
-    if card.ability.set == "Joker" and #G.jokers.cards >= G.jokers.config.card_limit then
-        return ExecutionResult.failure("You do not have enough space to add a joker.")
+    if card.ability.set == "Joker" and #G.jokers.cards >= G.jokers.config.card_limit
+        and (card.edition == nil or card.edition.key ~= "e_negative") then
+            return ExecutionResult.failure("You do not have enough space to buy this joker.")
     end
 
-    if card.ability.set ~= "Joker" and selected_action == "buy" and #G.consumeables.cards >= G.consumeables.config.card_limit then -- might cause issues with modded sets if they don't use G.consumeables
+    -- idt consumables in shop can ever have a modifier but lets check for it anyway
+    if (card.ability.set == "Planet" or card.ability.set == "Tarot" or card.ability.set == "Spectral")
+        and selected_action == "buy" and #G.consumeables.cards >= G.consumeables.config.card_limit
+        and (card.edition == nil or card.edition.key ~= "e_negative") then -- might cause issues with modded sets if they don't use G.consumeables
+        
         return ExecutionResult.failure(
-            "You can not store this card, due to there already being too many consumables stored. You should either use of some of the stored consumables or just buy this one.")
+            "You do not have enough space to buy this consumable.")
     end
 
     if selected_action == "buy and use" and not card:can_use_consumeable() then

--- a/custom-actions/skip_pack.lua
+++ b/custom-actions/skip_pack.lua
@@ -27,7 +27,11 @@ function SkipPack:_get_schema()
 end
 
 function SkipPack:_validate_action(data, state)
-	return ExecutionResult.success("Skipping this " .. SMODS.OPENED_BOOSTER.config.center.name)
+    local name = SMODS.OPENED_BOOSTER.config.center.name
+    if SMODS.OPENED_BOOSTER.config.center.mod and SMODS.OPENED_BOOSTER.config.center.loc_txt then
+        name = SMODS.OPENED_BOOSTER.config.center.loc_txt.name
+    end
+	return ExecutionResult.success("Skipping this " .. name)
 end
 
 function SkipPack:_execute_action(state)

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -64,7 +64,8 @@ function GetRunText:get_celestial_details(card_hand,add_cost,count)
                     SMODS.PokerHand.obj_table[v.config.hand_type].level,localize(v.config.hand_type, 'poker_hands'), SMODS.PokerHand.obj_table[v.config.hand_type].l_mult, SMODS.PokerHand.obj_table[v.config.hand_type].l_chips,
                     colours = {(SMODS.PokerHand.obj_table[v.config.hand_type].level==1 and G.C.UI.TEXT_DARK or G.C.HAND_LEVELS[math.min(7, SMODS.PokerHand.obj_table[v.config.hand_type].level)])}
                     }
-                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
+                
+                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args, AUT = card:generate_UIBox_ability_table()}
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
@@ -141,8 +142,8 @@ function GetRunText:get_joker_details(card_hand,add_cost,count)
                     loc_args = LOC_ARGS
                     key_override = card.config.center_key
                 end
-
-                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
+                
+                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args, AUT = card:generate_UIBox_ability_table()}
 
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 if name == "Misprint" then
@@ -224,7 +225,7 @@ function GetRunText:get_spectral_details(card_hand,add_cost,count)
                     sendErrorMessage("Could not find localize for card" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
+                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = card:generate_UIBox_ability_table()}
 
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -303,7 +304,7 @@ function GetRunText:get_tarot_details(card_hand,add_cost,count)
                     sendErrorMessage("Could not find localize for card" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
+                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args, AUT = card:generate_UIBox_ability_table()}
 
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -359,7 +360,7 @@ function GetRunText:get_booster_details(boosters,add_cost,count)
                     loc_args = {booster.config.center.config.choose,booster.config.center.config.extra}
                 end
 
-                localize{type = 'descriptions', key = key_override, set = "Other" or booster.ability.set, nodes = loc_nodes, vars = loc_args, AUT = booster.ability_UIBox_table}
+                localize{type = 'descriptions', key = key_override, set = "Other" or booster.ability.set, nodes = loc_nodes, vars = loc_args, AUT = booster:generate_UIBox_ability_table()}
 
                 local description = "\n" .. (count and ("- " .. #shop_boosters + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -413,7 +414,7 @@ function GetRunText:get_voucher_details(voucher_table,add_cost,count)
                     sendErrorMessage("Could not find localize for card" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = voucher.ability_UIBox_table}
+                localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = voucher:generate_UIBox_ability_table()}
 
                 local description = "\n" .. (count and ("- " .. #vouchers + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -619,7 +620,7 @@ function GetRunText:get_hand_editions(cards_table)
                     sendErrorMessage("Could not find localize for edition" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
+                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args}
 
                 local description = "\n -- " .. name .. " : "
                 description = get_text(loc_nodes,description)
@@ -668,7 +669,7 @@ function GetRunText:get_hand_enhancements(cards_table)
                     set_override = "Other"
                 end
 
-                localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
+                localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
 
                 local description = "\n -- " .. name .. " : "
                 description = get_text(loc_nodes,description)
@@ -763,7 +764,8 @@ function GetRunText:get_all_modifiers()
         local description,func_name,loc_args = get_modifiers_vars(g_card,loc_lookup)
         if func_name ~= "" then name = func_name end
 
-        localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table}
+
+        localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args}
 
         description = get_text(loc_nodes,description)
         -- is this hacky? yes. do i have a better idea? no
@@ -789,7 +791,7 @@ function GetRunText:get_all_modifiers()
             loc_args = {1.5}
         end
 
-        localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
+        localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
 
         description = get_text(loc_nodes,description)
 
@@ -808,7 +810,7 @@ function GetRunText:get_all_modifiers()
             key_override = loc_args[1] -- seal loc gets key not args
         end
 
-        localize{type = 'descriptions', set = "Other" or g_card.set, key= key_override or g_card.key, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table}
+        localize{type = 'descriptions', set = "Other" or g_card.set, key= key_override or g_card.key, nodes = loc_nodes, vars = loc_args}
 
         description = get_text(loc_nodes,description)
 

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -7,6 +7,19 @@ local function add_card_buy_cost(description,card)
     return description
 end
 
+local function add_consumeable_edition(desc, card)
+    if not card.edition then return desc end
+    desc = desc .. ". Edition: "
+    for _, v in ipairs(G.P_CENTER_POOLS.Edition) do
+        if v.key == card.edition.key and v.loc_txt then
+            desc = desc .. v.loc_txt.name
+        elseif v.key == card.edition.key then
+            desc = desc .. v.name
+        end
+    end
+    return desc
+end
+
 function GetRunText:get_celestial_names(card_hand)
     local cards = {}
 
@@ -65,6 +78,7 @@ function GetRunText:get_celestial_details(card_hand,add_cost,count)
                 end
 
                 if add_cost then description = add_card_buy_cost(description,card) end
+                description = add_consumeable_edition(description, card)
                 planet_desc = description
             ::continue::
             end
@@ -229,6 +243,7 @@ function GetRunText:get_spectral_details(card_hand,add_cost,count)
                 end
 
                 if add_cost then description = add_card_buy_cost(description,card) end
+                description = add_consumeable_edition(description, card)
                 spectral_desc = description
             ::continue::
             end
@@ -307,6 +322,7 @@ function GetRunText:get_tarot_details(card_hand,add_cost,count)
                 end
 
                 if add_cost then description = add_card_buy_cost(description,card) end
+                description = add_consumeable_edition(description, card)
                 tarot_desc = description
             ::continue::
             end

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -766,8 +766,14 @@ function GetRunText:get_all_modifiers()
         localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args}
 
         description = get_text(loc_nodes,description)
-
-        edition_descriptions[#edition_descriptions+1] = "\n -- " .. name.. " : " .. description
+        -- is this hacky? yes. do i have a better idea? no
+        if g_card.key == 'e_negative' then
+            edition_descriptions[#edition_descriptions+1] = "\n -- Negative (on Jokers) : +1 Joker slot"
+            edition_descriptions[#edition_descriptions+1] = "\n -- Negative (on Consumables) : +1 Consumables slot"
+            edition_descriptions[#edition_descriptions+1] = "\n -- Negative (on Playing Cards) : +1 hand size"
+        else
+            edition_descriptions[#edition_descriptions+1] = "\n -- " .. name.. " : " .. description
+        end
     end
 
     for _, g_card in pairs(G.P_CENTER_POOLS.Enhanced) do

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -64,7 +64,7 @@ function GetRunText:get_celestial_details(card_hand,add_cost,count)
                     SMODS.PokerHand.obj_table[v.config.hand_type].level,localize(v.config.hand_type, 'poker_hands'), SMODS.PokerHand.obj_table[v.config.hand_type].l_mult, SMODS.PokerHand.obj_table[v.config.hand_type].l_chips,
                     colours = {(SMODS.PokerHand.obj_table[v.config.hand_type].level==1 and G.C.UI.TEXT_DARK or G.C.HAND_LEVELS[math.min(7, SMODS.PokerHand.obj_table[v.config.hand_type].level)])}
                     }
-                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
                     for _, word in ipairs(line) do
@@ -142,7 +142,7 @@ function GetRunText:get_joker_details(card_hand,add_cost,count)
                     key_override = card.config.center_key
                 end
 
-                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = v.key, set = v.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
 
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 if name == "Misprint" then
@@ -224,7 +224,7 @@ function GetRunText:get_spectral_details(card_hand,add_cost,count)
                     sendErrorMessage("Could not find localize for card" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
 
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -303,7 +303,7 @@ function GetRunText:get_tarot_details(card_hand,add_cost,count)
                     sendErrorMessage("Could not find localize for card" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
 
                 local description = "\n" .. (count and ("- " .. #cards + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -359,7 +359,7 @@ function GetRunText:get_booster_details(boosters,add_cost,count)
                     loc_args = {booster.config.center.config.choose,booster.config.center.config.extra}
                 end
 
-                localize{type = 'descriptions', key = key_override, set = "Other" or booster.ability.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = key_override, set = "Other" or booster.ability.set, nodes = loc_nodes, vars = loc_args, AUT = booster.ability_UIBox_table}
 
                 local description = "\n" .. (count and ("- " .. #shop_boosters + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -413,7 +413,7 @@ function GetRunText:get_voucher_details(voucher_table,add_cost,count)
                     sendErrorMessage("Could not find localize for card" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = voucher.ability_UIBox_table}
 
                 local description = "\n" .. (count and ("- " .. #vouchers + 1 .. ": ") or "") .. name .. ": "
                 for _, line in ipairs(loc_nodes) do
@@ -619,7 +619,7 @@ function GetRunText:get_hand_editions(cards_table)
                     sendErrorMessage("Could not find localize for edition" .. g_card.key)
                 end
 
-                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args}
+                localize{type = 'descriptions', key = g_card.key or key_override, set = g_card.set or card.ability.set, nodes = loc_nodes, vars = loc_args, AUT = card.ability_UIBox_table}
 
                 local description = "\n -- " .. name .. " : "
                 description = get_text(loc_nodes,description)
@@ -668,7 +668,7 @@ function GetRunText:get_hand_enhancements(cards_table)
                     set_override = "Other"
                 end
 
-                localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
+                localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
 
                 local description = "\n -- " .. name .. " : "
                 description = get_text(loc_nodes,description)
@@ -763,7 +763,7 @@ function GetRunText:get_all_modifiers()
         local description,func_name,loc_args = get_modifiers_vars(g_card,loc_lookup)
         if func_name ~= "" then name = func_name end
 
-        localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args}
+        localize{type = 'descriptions', key = g_card.key, set = g_card.set, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table}
 
         description = get_text(loc_nodes,description)
         -- is this hacky? yes. do i have a better idea? no
@@ -789,7 +789,7 @@ function GetRunText:get_all_modifiers()
             loc_args = {1.5}
         end
 
-        localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
+        localize{type = 'descriptions', key = key_override or g_card.key, set = set_override or g_card.set, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table} -- doesn't get character's like + idk why as others do, needs to be fixed before releasing though
 
         description = get_text(loc_nodes,description)
 
@@ -808,7 +808,7 @@ function GetRunText:get_all_modifiers()
             key_override = loc_args[1] -- seal loc gets key not args
         end
 
-        localize{type = 'descriptions', set = "Other" or g_card.set, key= key_override or g_card.key, nodes = loc_nodes, vars = loc_args}
+        localize{type = 'descriptions', set = "Other" or g_card.set, key= key_override or g_card.key, nodes = loc_nodes, vars = loc_args, AUT = g_card.ability_UIBox_table}
 
         description = get_text(loc_nodes,description)
 

--- a/neuro_sama_integration.json
+++ b/neuro_sama_integration.json
@@ -6,5 +6,5 @@
   "description": "A mod that enables Neuro-Sama to play Balatro",
   "prefix": "neuro_integration",
   "main_file": "main.lua",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/run_functions_helper.lua
+++ b/run_functions_helper.lua
@@ -86,26 +86,24 @@ function RunHelper:get_query_string(state)
         end
     end
 
+    state_string = state_string .. string.format("\nYou currently have %d/%d jokers in your inventory.", #G.jokers.cards, G.jokers.config.card_limit)
     if #G.jokers.cards > 0 then
         local cards = GetRunText:get_card_modifiers(G.jokers.cards)
 
         for pos, value in ipairs(cards) do
             cards[pos] = "\n" .. pos .. ": " .. string.sub(value,2) .. ". Sell value: $" .. G.jokers.cards[pos].sell_cost
         end
-        state_string = state_string .. "\nThese are the jokers in your hand, their abilites, modifiers and sell value: ".. table.concat(cards, "", 1, #cards)
-    else
-        state_string = state_string .. "\nYou do not have any jokers as of right now."
+        state_string = state_string .. " Here is a list of their abilites, modifiers and sell value: ".. table.concat(cards, "", 1, #cards)
     end
 
+    state_string = state_string .. string.format("\nYou currently have %d/%d consumables in your inventory.", #G.consumeables.cards, G.consumeables.config.card_limit)
     if #G.consumeables.cards > 0 then
         local cards = GetRunText:get_consumeables_text(G.consumeables.cards)
 
         for pos, value in ipairs(cards) do
             cards[pos] = "\n" .. pos .. ": " .. value .. ". Sell value: $" .. G.consumeables.cards[pos].sell_cost
         end
-        state_string = state_string .. "\nThese are the names of the consumables in your hand, their abilities and their sell value: " .. table.concat(cards, "", 1, #cards)
-    else
-        state_string = state_string .. "\nYou do not have any consumables as of right now."
+        state_string = state_string .. " Here is a list of their abilities and sell value: " .. table.concat(cards, "", 1, #cards)
     end
 
     return query_string, state_string


### PR DESCRIPTION
This started off as a fix to negative related cards... but I ended up fixing other stuff I found. Oh well, here's the full changelog:

- Adds seperate descriptions for negative cards on jokers/consumables/playing cards
- Adds editions to consumables 
- Adds current/total count for jokers and consumables in inventory
- Fixed crash for cards with nested tables in description (only seems to affect Noriko from Neuratro)
- Fixed issue with checking inventory space when buying cards/taking from a pack
- Fixed issue with modded booster names in open pack/skip pack execution result