### PR TITLE
Consoldiate all globals into a single table

### DIFF
--- a/card_info.lua
+++ b/card_info.lua
@@ -1,10 +1,10 @@
-Non_Valid_Add_Joker_Consumables = {
+NEURO.CARD_INFO.ADD_JOKER_CONSUMABLE_OVERWRITE = {
 	c_wraith = false,
 	c_soul = false,
 	c_judgement = false
 }
 
-Non_Valid_Modify_Joker_Consumables = {
+NEURO.CARD_INFO.MODIFY_JOKER_CONSUMABLE_OVERWRITE = {
 	c_hex = false,
 	c_ectoplasm = false,
 	c_ankh = false,

--- a/config_manager.lua
+++ b/config_manager.lua
@@ -1,12 +1,24 @@
 local ConfigManager = {}
-local default_cfg = ModCache.load("config.lua")
-local status, user_cfg = pcall(ModCache.load, "_config.lua")
+local default_cfg = NEURO.MOD_CACHE.load("config.lua")
+local status, user_cfg = pcall(NEURO.MOD_CACHE.load, "_config.lua")
 if not status then user_cfg = {}; print("Local user config not found.") end
 
 
 function ConfigManager.get(key)
     if user_cfg[key] ~= nil then return user_cfg[key] end
     return default_cfg[key]
+end
+
+function ConfigManager.get_tbl()
+    local cfg = {}
+    for k, v in pairs(default_cfg) do
+        if user_cfg[k] ~= nil then
+            cfg[k] = user_cfg[k]
+        else
+            cfg[k] = default_cfg[k]
+        end
+    end
+    return cfg
 end
 
 return ConfigManager

--- a/custom-actions/deck_type.lua
+++ b/custom-actions/deck_type.lua
@@ -1,9 +1,9 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
 local DeckInfo = setmetatable({}, { __index = NeuroAction })
 DeckInfo.__index = DeckInfo
 
@@ -42,7 +42,7 @@ function DeckInfo:_validate_action(data, state)
     if not table.any(option, function(options)
             return options == action
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("information_action"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("information_action"))
     end
 
 	if #G.deck.cards < 1 then

--- a/custom-actions/get_poker_hand_info.lua
+++ b/custom-actions/get_poker_hand_info.lua
@@ -1,9 +1,9 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
-local RunContext = ModCache.load("run_context.lua")
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
 local PokerHandInfo = setmetatable({}, { __index = NeuroAction })
 PokerHandInfo.__index = PokerHandInfo
 

--- a/custom-actions/joker_interaction.lua
+++ b/custom-actions/joker_interaction.lua
@@ -1,10 +1,10 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local JokerInteraction = setmetatable({}, { __index = NeuroAction })
 JokerInteraction.__index = JokerInteraction
@@ -72,10 +72,10 @@ function JokerInteraction:_validate_action(data, state)
     if not table.any(option, function(options)
             return options == selected_action
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("card_action"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("card_action"))
     end
 
-    if #selected_hand_index == 0 then return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter(
+    if #selected_hand_index == 0 then return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter(
         "selected_hand_index")) end
     if selected_action == "Move" then
         if #G.jokers.cards == 1 then return ExecutionResult.failure(

--- a/custom-actions/modifier_information.lua
+++ b/custom-actions/modifier_information.lua
@@ -1,9 +1,9 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
-local RunContext = ModCache.load("run_context.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
 
 local ModifierInformation = setmetatable({}, { __index = NeuroAction })
 ModifierInformation.__index = ModifierInformation

--- a/custom-actions/pick_hand_pack_cards.lua
+++ b/custom-actions/pick_hand_pack_cards.lua
@@ -1,16 +1,16 @@
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
 
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
 
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
-local SkipPack = ModCache.load("custom-actions/skip_pack.lua")
-local JokerInteraction = ModCache.load("custom-actions/joker_interaction.lua")
-local UseConsumable = ModCache.load("custom-actions/use_consumables.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
+local SkipPack = NEURO.MOD_CACHE.load("custom-actions/skip_pack.lua")
+local JokerInteraction = NEURO.MOD_CACHE.load("custom-actions/joker_interaction.lua")
+local UseConsumable = NEURO.MOD_CACHE.load("custom-actions/use_consumables.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
-local RunContext = ModCache.load("run_context.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
 
 local PickHandPackCards = setmetatable({}, { __index = NeuroAction })
 PickHandPackCards.__index = PickHandPackCards
@@ -98,7 +98,7 @@ function PickHandPackCards:_validate_action(data, state)
     if not table.any(valid_hand_indices, function(options)
             return options == selected_pack_card
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("pack_card_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("pack_card_index"))
     end
 
     if #selected_hand_index > G.hand.config.highlighted_limit then

--- a/custom-actions/pick_pack_card.lua
+++ b/custom-actions/pick_pack_card.lua
@@ -1,15 +1,15 @@
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
 
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 
-local SkipPack = ModCache.load("custom-actions/skip_pack.lua")
-local JokerInteraction = ModCache.load("custom-actions/joker_interaction.lua")
-local UseConsumable = ModCache.load("custom-actions/use_consumables.lua")
+local SkipPack = NEURO.MOD_CACHE.load("custom-actions/skip_pack.lua")
+local JokerInteraction = NEURO.MOD_CACHE.load("custom-actions/joker_interaction.lua")
+local UseConsumable = NEURO.MOD_CACHE.load("custom-actions/use_consumables.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local PickCards = setmetatable({}, { __index = NeuroAction })
 PickCards.__index = PickCards
@@ -76,7 +76,7 @@ function PickCards:_validate_action(data, state)
     if not table.any(valid_hand_indices, function(options)
             return options == selected_hand_index
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("pack_card_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("pack_card_index"))
     end
 
     local selected_card = G.pack_cards.cards[selected_hand_index]

--- a/custom-actions/play_blind.lua
+++ b/custom-actions/play_blind.lua
@@ -1,7 +1,7 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local PlayBlind = setmetatable({}, { __index = NeuroAction })
 PlayBlind.__index = PlayBlind

--- a/custom-actions/reroll_blind.lua
+++ b/custom-actions/reroll_blind.lua
@@ -1,9 +1,9 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local PlayBlind = ModCache.load("custom-actions/play_blind.lua")
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local PlayBlind = NEURO.MOD_CACHE.load("custom-actions/play_blind.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 local RerollBlind = setmetatable({}, { __index = NeuroAction })
 RerollBlind.__index = RerollBlind
 

--- a/custom-actions/select_deck.lua
+++ b/custom-actions/select_deck.lua
@@ -1,10 +1,10 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local PreRunLoc = ModCache.load("pre_run_loc.lua")
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local SelectStake = ModCache.load("custom-actions/select_stake.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local PreRunLoc = NEURO.MOD_CACHE.load("pre_run_loc.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local SelectStake = NEURO.MOD_CACHE.load("custom-actions/select_stake.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local SelectDeck = setmetatable({}, { __index = NeuroAction })
 SelectDeck.__index = SelectDeck
@@ -49,14 +49,14 @@ end
 function SelectDeck:_validate_action(data, state)
     local back = data:get_string("deck")
     if not back then
-        return ExecutionResult.failure(SDK_Strings.action_failed_missing_required_parameter("deck"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_missing_required_parameter("deck"))
     end
 
     local backs = PreRunLoc:get_back_names()
     if not table.any(backs, function(possible_back)
             return possible_back == back
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("deck"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("deck"))
     end
     state["deck"] = back
     return ExecutionResult.success(string.format("Starting the game with the %s.", back))

--- a/custom-actions/select_stake.lua
+++ b/custom-actions/select_stake.lua
@@ -1,8 +1,8 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local PreRunLoc = ModCache.load("pre_run_loc.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local PreRunLoc = NEURO.MOD_CACHE.load("pre_run_loc.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local SelectStake = setmetatable({}, { __index = NeuroAction })
 SelectStake.__index = SelectStake
@@ -37,14 +37,14 @@ end
 function SelectStake:_validate_action(data, state)
     local stake = data:get_string("stake")
     if not stake then
-        return ExecutionResult.failure(SDK_Strings.action_failed_missing_required_parameter("stake"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_missing_required_parameter("stake"))
     end
 
     local stakes = PreRunLoc:get_stake_names()
     if not table.any(stakes, function(possible_stake)
             return possible_stake == stake
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("stake"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("stake"))
     end
     state["stake"] = stake
     return ExecutionResult.success("The game has started with the " .. stake)

--- a/custom-actions/shop-actions/buy_shop_booster.lua
+++ b/custom-actions/shop-actions/buy_shop_booster.lua
@@ -1,8 +1,8 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 local BuyBooster = setmetatable({}, { __index = NeuroAction })
 BuyBooster.__index = BuyBooster
 
@@ -34,7 +34,7 @@ function BuyBooster:_validate_action(data, state)
 
 	local valid_booster_indices = RunHelper:get_hand_length(G.shop_booster.cards)
     if not RunHelper:value_in_table(valid_booster_indices,selected_index) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("booster_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("booster_index"))
     end
 
 	local booster = G.shop_booster.cards[selected_index]

--- a/custom-actions/shop-actions/buy_shop_card.lua
+++ b/custom-actions/shop-actions/buy_shop_card.lua
@@ -1,9 +1,9 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local BuyShopCard = setmetatable({}, { __index = NeuroAction })
 BuyShopCard.__index = BuyShopCard
@@ -45,12 +45,12 @@ function BuyShopCard:_validate_action(data, state)
 
     local option = card_actions()
     if not RunHelper:value_in_table(option, selected_action) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("card_action"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("card_action"))
     end
 
     local valid_hand_indices = RunHelper:get_hand_length(G.shop_jokers.cards)
     if not RunHelper:value_in_table(valid_hand_indices, selected_index) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("card_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("card_index"))
     end
 
     local card = G.shop_jokers.cards[selected_index]

--- a/custom-actions/shop-actions/buy_shop_voucher.lua
+++ b/custom-actions/shop-actions/buy_shop_voucher.lua
@@ -1,9 +1,9 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local BuyVoucher = setmetatable({}, { __index = NeuroAction })
 BuyVoucher.__index = BuyVoucher
@@ -48,7 +48,7 @@ function BuyVoucher:_validate_action(data, state)
 
     local valid_voucher_indices = RunHelper:get_hand_length(G.shop_vouchers.cards)
     if not RunHelper:value_in_table(valid_voucher_indices,selected_index) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("voucher_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("voucher_index"))
     end
 
     state["voucher_index"] = selected_index

--- a/custom-actions/shop-actions/exit_shop.lua
+++ b/custom-actions/shop-actions/exit_shop.lua
@@ -1,10 +1,10 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
-local JokerInteraction = ModCache.load("custom-actions/joker_interaction.lua")
-local UseConsumables = ModCache.load("custom-actions/use_consumables.lua")
+local JokerInteraction = NEURO.MOD_CACHE.load("custom-actions/joker_interaction.lua")
+local UseConsumables = NEURO.MOD_CACHE.load("custom-actions/use_consumables.lua")
 
 local ExitShop = setmetatable({}, { __index = NeuroAction })
 ExitShop.__index = ExitShop

--- a/custom-actions/shop-actions/reroll_shop.lua
+++ b/custom-actions/shop-actions/reroll_shop.lua
@@ -1,6 +1,6 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local RerollShop = setmetatable({}, { __index = NeuroAction })
 RerollShop.__index = RerollShop

--- a/custom-actions/skip_blind.lua
+++ b/custom-actions/skip_blind.lua
@@ -1,10 +1,10 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local PlayBlind = ModCache.load("custom-actions/play_blind.lua")
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
-local RerollBlind = ModCache.load("custom-actions/reroll_blind.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local PlayBlind = NEURO.MOD_CACHE.load("custom-actions/play_blind.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
+local RerollBlind = NEURO.MOD_CACHE.load("custom-actions/reroll_blind.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 local SkipBlind = setmetatable({}, { __index = NeuroAction })
 SkipBlind.__index = SkipBlind
 

--- a/custom-actions/skip_pack.lua
+++ b/custom-actions/skip_pack.lua
@@ -1,8 +1,8 @@
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
 
 SkipPack = setmetatable({}, { __index = NeuroAction })
 SkipPack.__index = SkipPack

--- a/custom-actions/use_consumables.lua
+++ b/custom-actions/use_consumables.lua
@@ -1,13 +1,13 @@
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
 
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
 
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local UseConsumable = setmetatable({}, { __index = NeuroAction })
 UseConsumable.__index = UseConsumable
@@ -73,7 +73,7 @@ function UseConsumable:_validate_action(data, state)
     if not table.any(indexs, function(options) -- check Neuro doesn't send a invalid index
             return options == selected_consumable
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("consumable_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("consumable_index"))
     end
 
     local card = G.consumeables.cards[tonumber(selected_consumable)]
@@ -91,7 +91,7 @@ function UseConsumable:_validate_action(data, state)
     if not table.any(option, function(options)
             return options == selected_action
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("card_action"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("card_action"))
     end
 
     local valid_hand_indices = RunHelper:get_hand_length(G.hand.cards)

--- a/custom-actions/use_hand_cards.lua
+++ b/custom-actions/use_hand_cards.lua
@@ -1,10 +1,10 @@
-local Context = ModCache.load("game-sdk/messages/outgoing/Context.lua")
-local NeuroAction = ModCache.load("game-sdk/actions/neuro_action.lua")
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/Context.lua")
+local NeuroAction = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
 
-local JsonUtils = ModCache.load("game-sdk/utils/json_utils.lua")
+local JsonUtils = NEURO.MOD_CACHE.load("game-sdk/utils/json_utils.lua")
 
 local UseHandCards = setmetatable({}, { __index = NeuroAction })
 UseHandCards.__index = UseHandCards
@@ -55,14 +55,14 @@ function UseHandCards:_validate_action(data, state)
     selected_index = selected_index._data
 
     if not selected_index then
-        return ExecutionResult.failure(SDK_Strings.action_failed_missing_required_parameter("card_action"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_missing_required_parameter("card_action"))
     end
 
     local option = card_action_options()
     if not table.any(option, function(options)
             return options == selected_action
         end) then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_parameter("card_action"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_parameter("card_action"))
     end
 
     local valid_hand_indices = RunHelper:get_hand_length(G.hand.cards)
@@ -77,7 +77,7 @@ function UseHandCards:_validate_action(data, state)
     end
 
     if not selected_index then
-        return ExecutionResult.failure(SDK_Strings.action_failed_missing_required_parameter("cards_index"))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_missing_required_parameter("cards_index"))
     end
 
     if #selected_index == 0 then return ExecutionResult.failure("At least one card must be selected.") end

--- a/deck_loc.lua
+++ b/deck_loc.lua
@@ -1,4 +1,4 @@
-Back_Loc = {
+NEURO.LOCS.BACK = {
     b_red = { "discards" },
     b_blue = { "hands" },
     b_yellow = { "dollars" },
@@ -26,7 +26,7 @@ Back_Loc = {
     b_erratic = {}
 }
 
-Stake_Loc = {
+NEURO.LOCS.STAKE = {
     stake_gold = {},
     stake_white = {},
     stake_red = {},

--- a/game-sdk/actions/action_window.lua
+++ b/game-sdk/actions/action_window.lua
@@ -3,11 +3,11 @@
 
 -- Modified by LuqDude
 
-local ActionsForce = ModCache.load("game-sdk/messages/outgoing/action_force.lua")
+local ActionsForce = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/action_force.lua")
 
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
-local WebsocketConnection = ModCache.load("game-sdk/websocket/websocket_connection.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
+local WebsocketConnection = NEURO.MOD_CACHE.load("game-sdk/websocket/websocket_connection.lua")
 
 State = {
     BUILDING = 1,

--- a/game-sdk/actions/neuro_action.lua
+++ b/game-sdk/actions/neuro_action.lua
@@ -4,8 +4,8 @@
 -- Modified by LuqDude in 2025
 
 
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local WsAction = ModCache.load("game-sdk/actions/ws_action.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local WsAction = NEURO.MOD_CACHE.load("game-sdk/actions/ws_action.lua")
 
 
 local NeuroAction = {}

--- a/game-sdk/actions/neuro_action_handler.lua
+++ b/game-sdk/actions/neuro_action_handler.lua
@@ -4,9 +4,9 @@
 -- Modified by LuqDude in 2025
 
 
-local WebsocketConnection = ModCache.load("game-sdk/websocket/websocket_connection.lua")
-local ActionsRegister = ModCache.load("game-sdk/messages/outgoing/actions_register.lua")
-local ActionsUnregister = ModCache.load("game-sdk/messages/outgoing/action_unregister.lua")
+local WebsocketConnection = NEURO.MOD_CACHE.load("game-sdk/websocket/websocket_connection.lua")
+local ActionsRegister = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/actions_register.lua")
+local ActionsUnregister = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/action_unregister.lua")
 
 local NeuroActionHandler = {}
 NeuroActionHandler.__index = NeuroActionHandler

--- a/game-sdk/game_hooks.lua
+++ b/game-sdk/game_hooks.lua
@@ -3,10 +3,10 @@
 
 -- Modified by LuqDude
 
-local WebsocketConnection = ModCache.load("game-sdk/websocket/websocket_connection.lua")
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
+local WebsocketConnection = NEURO.MOD_CACHE.load("game-sdk/websocket/websocket_connection.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
 
-local Action = ModCache.load("game-sdk/messages/incoming/action.lua")
+local Action = NEURO.MOD_CACHE.load("game-sdk/messages/incoming/action.lua")
 
 local GameHooks = {}
 

--- a/game-sdk/messages/api/incoming_message.lua
+++ b/game-sdk/messages/api/incoming_message.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
 
 local IncomingMessage = {}
 IncomingMessage.__index = IncomingMessage
@@ -16,7 +16,7 @@ function IncomingMessage:validate(command, message_data, state)
     local result = self:_validate(command, message_data, state)
     if result == nil then
         print("IncomingMessage._validate() returned null. An error probably occurred.")
-        return ExecutionResult.mod_failure(SDK_Strings.action_failed_error)
+        return ExecutionResult.mod_failure(NEURO.SDK_STRINGS.action_failed_error)
     end
     return result
 end

--- a/game-sdk/messages/api/outgoing_message.lua
+++ b/game-sdk/messages/api/outgoing_message.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-local WsMessage = ModCache.load("game-sdk/messages/api/ws_message.lua")
+local WsMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/ws_message.lua")
 
 local OutgoingMessage = {}
 OutgoingMessage.__index = OutgoingMessage

--- a/game-sdk/messages/incoming/action.lua
+++ b/game-sdk/messages/incoming/action.lua
@@ -3,16 +3,16 @@
 
 -- Modified by LuqDude
 
-local ExecutionResult = ModCache.load("game-sdk/websocket/execution_result.lua")
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
-local IncomingData = ModCache.load("game-sdk/messages/api/incoming_data.lua")
-local IncomingMessage = ModCache.load("game-sdk/messages/api/incoming_message.lua")
-local WebsocketConnection = ModCache.load("game-sdk/websocket/websocket_connection.lua")
+local ExecutionResult = NEURO.MOD_CACHE.load("game-sdk/websocket/execution_result.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
+local IncomingData = NEURO.MOD_CACHE.load("game-sdk/messages/api/incoming_data.lua")
+local IncomingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/incoming_message.lua")
+local WebsocketConnection = NEURO.MOD_CACHE.load("game-sdk/websocket/websocket_connection.lua")
 
-local ActionResult = ModCache.load("game-sdk/messages/outgoing/action_result.lua")
+local ActionResult = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/action_result.lua")
 
 
-local json = ModCache.load("libs/json.lua")
+local json = NEURO.MOD_CACHE.load("libs/json.lua")
 
 
 local Action = setmetatable({}, { __index = IncomingMessage })
@@ -29,12 +29,12 @@ end
 
 function Action:_validate(_command, message_data, state)
     if message_data == nil then
-        return ExecutionResult.vedal_failure(SDK_Strings.action_failed_no_data)
+        return ExecutionResult.vedal_failure(NEURO.SDK_STRINGS.action_failed_no_data)
     end
 
     local action_id = message_data:get_string("id")
     if not action_id then
-        return ExecutionResult.vedal_failure(SDK_Strings.action_failed_no_id)
+        return ExecutionResult.vedal_failure(NEURO.SDK_STRINGS.action_failed_no_id)
     end
 
     state._action_id = action_id
@@ -43,27 +43,27 @@ function Action:_validate(_command, message_data, state)
     local action_stringified_data = message_data:get_string("data", "{}")
 
     if action_name == nil or action_name == "" then
-        return ExecutionResult.vedal_failure(SDK_Strings.action_failed_no_name)
+        return ExecutionResult.vedal_failure(NEURO.SDK_STRINGS.action_failed_no_name)
     end
 
     local action = NeuroActionHandler.get_action(action_name)
     if action == nil then
         if NeuroActionHandler.is_recently_unregistered(action_name) then
-            return ExecutionResult.failure(SDK_Strings.action_failed_unregistered)
+            return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_unregistered)
         end
-        return ExecutionResult.failure(SDK_Strings.action_failed_unknown_action(action_name))
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_unknown_action(action_name))
     end
 
     state._action_instance = action
 
     local success, parsed_data = pcall(json.decode, action_stringified_data)
     if not success then
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_json)
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_json)
     end
 
     if type(parsed_data) ~= 'table' then
         print("Action data can only be a table.")
-        return ExecutionResult.failure(SDK_Strings.action_failed_invalid_json)
+        return ExecutionResult.failure(NEURO.SDK_STRINGS.action_failed_invalid_json)
     end
 
     local action_data = IncomingData:new(parsed_data)

--- a/game-sdk/messages/outgoing/action_force.lua
+++ b/game-sdk/messages/outgoing/action_force.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-local OutgoingMessage = ModCache.load("game-sdk/messages/api/outgoing_message.lua")
+local OutgoingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/outgoing_message.lua")
 
 local ActionsForce = setmetatable({}, { __index = OutgoingMessage })
 ActionsForce.__index = ActionsForce

--- a/game-sdk/messages/outgoing/action_result.lua
+++ b/game-sdk/messages/outgoing/action_result.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-local OutgoingMessage = ModCache.load("game-sdk/messages/api/outgoing_message.lua")
+local OutgoingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/outgoing_message.lua")
 
 local ActionResult = setmetatable({}, { __index = OutgoingMessage })
 ActionResult.__index = ActionResult

--- a/game-sdk/messages/outgoing/action_unregister.lua
+++ b/game-sdk/messages/outgoing/action_unregister.lua
@@ -3,8 +3,8 @@
 
 -- Modified by LuqDude
 
-local OutgoingMessage = ModCache.load("game-sdk/messages/api/outgoing_message.lua")
-local ActionsRegister = ModCache.load("game-sdk/messages/outgoing/actions_register.lua")
+local OutgoingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/outgoing_message.lua")
+local ActionsRegister = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/actions_register.lua")
 
 local ActionsUnregister = setmetatable({}, { __index = OutgoingMessage })
 ActionsUnregister.__index = ActionsUnregister

--- a/game-sdk/messages/outgoing/actions_register.lua
+++ b/game-sdk/messages/outgoing/actions_register.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-local OutgoingMessage = ModCache.load("game-sdk/messages/api/outgoing_message.lua")
+local OutgoingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/outgoing_message.lua")
 
 local ActionsRegister = setmetatable({}, { __index = OutgoingMessage })
 ActionsRegister.__index = ActionsRegister

--- a/game-sdk/messages/outgoing/context.lua
+++ b/game-sdk/messages/outgoing/context.lua
@@ -3,8 +3,8 @@
 
 -- Modified by LuqDude
 
-local WebsocketConnection = ModCache.load("game-sdk/websocket/websocket_connection.lua")
-local OutgoingMessage = ModCache.load("game-sdk/messages/api/outgoing_message.lua")
+local WebsocketConnection = NEURO.MOD_CACHE.load("game-sdk/websocket/websocket_connection.lua")
+local OutgoingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/outgoing_message.lua")
 
 local Context = setmetatable({}, { __index = OutgoingMessage })
 Context.__index = Context

--- a/game-sdk/messages/outgoing/startup.lua
+++ b/game-sdk/messages/outgoing/startup.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-local OutgoingMessage = ModCache.load("game-sdk/messages/api/outgoing_message.lua")
+local OutgoingMessage = NEURO.MOD_CACHE.load("game-sdk/messages/api/outgoing_message.lua")
 
 local Startup = setmetatable({}, { __index = OutgoingMessage })
 Startup.__index = Startup

--- a/game-sdk/sdk_string_consts.lua
+++ b/game-sdk/sdk_string_consts.lua
@@ -3,7 +3,7 @@
 
 -- Modified by LuqDude
 
-SDK_Strings = {
+NEURO.SDK_STRINGS = {
     action_failed_invalid_json = "Action failed. Could not parse action parameters from JSON.",
     action_failed_no_data = "Action failed. Missing command data.",
     action_failed_no_id = "Action failed. Missing command field 'id'.",

--- a/game-sdk/websocket/execution_result.lua
+++ b/game-sdk/websocket/execution_result.lua
@@ -23,11 +23,11 @@ function ExecutionResult.failure(message)
 end
 
 function ExecutionResult.vedal_failure(message)
-    return ExecutionResult.failure(message .. SDK_Strings.action_failed_vedal_fault_suffix)
+    return ExecutionResult.failure(message .. NEURO.SDK_STRINGS.action_failed_vedal_fault_suffix)
 end
 
 function ExecutionResult.mod_failure(message)
-    return ExecutionResult.failure(message .. SDK_Strings.action_failed_mod_fault_suffix)
+    return ExecutionResult.failure(message .. NEURO.SDK_STRINGS.action_failed_mod_fault_suffix)
 end
 
 return ExecutionResult

--- a/game-sdk/websocket/websocket_connection.lua
+++ b/game-sdk/websocket/websocket_connection.lua
@@ -3,20 +3,20 @@
 
 -- Modified by LuqDude
 
-local websocket =  ModCache.load("libs/websocket.lua")
+local websocket =  NEURO.MOD_CACHE.load("libs/websocket.lua")
 
-local MessageQueue = ModCache.load("game-sdk/websocket/message_queue.lua")
-local CommandHandler = ModCache.load("game-sdk/websocket/command_handler.lua")
-local IncomingData = ModCache.load("game-sdk/messages/api/incoming_data.lua")
-local Startup = ModCache.load("game-sdk/messages/outgoing/startup.lua")
+local MessageQueue = NEURO.MOD_CACHE.load("game-sdk/websocket/message_queue.lua")
+local CommandHandler = NEURO.MOD_CACHE.load("game-sdk/websocket/command_handler.lua")
+local IncomingData = NEURO.MOD_CACHE.load("game-sdk/messages/api/incoming_data.lua")
+local Startup = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/startup.lua")
 
-local json = ModCache.load("libs/json.lua")
+local json = NEURO.MOD_CACHE.load("libs/json.lua")
 
 local WebsocketConnection = {}
 WebsocketConnection.__index = WebsocketConnection
 
-local RECONNECT_DELAY = NeuroConfig.get("RECONNECT_DELAY") or 5
-local WS_URL = NeuroConfig.get("NEURO_SDK_WS_URL")
+local RECONNECT_DELAY = NEURO.CONFIG["RECONNECT_DELAY"] or 5
+local WS_URL = NEURO.CONFIG["NEURO_SDK_WS_URL"]
 
 function WebsocketConnection:new()
     local self = setmetatable({}, WebsocketConnection)

--- a/game_prep.lua
+++ b/game_prep.lua
@@ -1,11 +1,11 @@
 local GamePrep = {}
 
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local SelectDeck = ModCache.load("custom-actions/select_deck.lua")
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local RunContext = ModCache.load("run_context.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local SelectDeck = NEURO.MOD_CACHE.load("custom-actions/select_deck.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
 
-local neuro_profile = NeuroConfig.get("PROFILE_SLOT")
+local neuro_profile = NEURO.CONFIG["PROFILE_SLOT"]
 
 local function load_profile(delay)
     G.E_MANAGER:add_event(Event({

--- a/get_run_text.lua
+++ b/get_run_text.lua
@@ -186,9 +186,9 @@ end
 function GetRunText.get_all_modifiers()
     local editions, enhancements, seals = {}, {}, {}
     local sets = {
-        {G.P_CENTER_POOLS.Edition, Edition_Loc, editions},
-        {G.P_CENTER_POOLS.Enhanced, Enhancement_Loc, enhancements},
-        {G.P_CENTER_POOLS.Seal, Seal_Loc, seals}
+        {G.P_CENTER_POOLS.Edition, NEURO.LOCS.EDITION, editions},
+        {G.P_CENTER_POOLS.Enhanced, NEURO.LOCS.ENHANCEMENT, enhancements},
+        {G.P_CENTER_POOLS.Seal, NEURO.LOCS.SEAL, seals}
     }
 
     for _, mod_set in ipairs(sets) do

--- a/globals.lua
+++ b/globals.lua
@@ -1,0 +1,29 @@
+NEURO = {
+    -- table with all the config values, with _config.lua taking priority over config.lua
+    CONFIG = {},
+    -- cache for lua modules
+    MOD_CACHE = {},
+    -- # of played blinds since we last sent voucher/modifier context 
+    PLAYED_BLINDS = 0,
+    -- how many blinds we should have before sending voucher/modifier context
+    MAX_PLAYED_BLINDS = 0,
+    -- localization lookup tables
+    LOCS = {
+        EDITION = {},
+        ENHANCEMENT = {},
+        SEAL = {},
+        BACK = {},
+        STAKE = {}
+    },
+    -- whether or not we can restart after a crash
+    CAN_RESTART = false,
+    -- additional card info
+    CARD_INFO = {
+        ADD_JOKER_CONSUMABLE_OVERWRITE = {},
+        MODIFY_JOKER_CONSUMABLE_OVERWRITE = {}
+    },
+    -- round evaluation data 
+    ROUND_EVAL = {},
+    -- strings used for SDK action failures
+    SDK_STRINGS = {}
+}

--- a/hook.lua
+++ b/hook.lua
@@ -1,27 +1,27 @@
-local GameHooks = ModCache.load("game-sdk/game_hooks.lua")
-local GamePrep = ModCache.load("game_prep.lua")
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
+local GameHooks = NEURO.MOD_CACHE.load("game-sdk/game_hooks.lua")
+local GamePrep = NEURO.MOD_CACHE.load("game_prep.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
 
-local SelectDeck = ModCache.load("custom-actions/select_deck.lua")
-local PlayingRun = ModCache.load("playing_run.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
-local RunContext = ModCache.load("run_context.lua")
+local SelectDeck = NEURO.MOD_CACHE.load("custom-actions/select_deck.lua")
+local PlayingRun = NEURO.MOD_CACHE.load("playing_run.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
 
-local PlayBlind = ModCache.load("custom-actions/play_blind.lua")
-local SkipBlind = ModCache.load("custom-actions/skip_blind.lua")
-local RerollBlind = ModCache.load("custom-actions/reroll_blind.lua")
+local PlayBlind = NEURO.MOD_CACHE.load("custom-actions/play_blind.lua")
+local SkipBlind = NEURO.MOD_CACHE.load("custom-actions/skip_blind.lua")
+local RerollBlind = NEURO.MOD_CACHE.load("custom-actions/reroll_blind.lua")
 
 
 local Hook = {}
 Hook.__index = Hook
 
-local should_unlock = NeuroConfig.get("UNLOCK_ALL")
-local neuro_profile = NeuroConfig.get("PROFILE_SLOT")
+local should_unlock = NEURO.CONFIG["UNLOCK_ALL"]
+local neuro_profile = NEURO.CONFIG["PROFILE_SLOT"]
 
-G.can_restart = NeuroConfig.get("CAN_RESTART_ON_CRASH")
-MAX_PLAYED_BLINDS = NeuroConfig.get("RESEND_MODIFIER_BLIND_AMOUNT")
-PLAYED_BLINDS = 0
+NEURO.CAN_RESTART = NEURO.CONFIG["CAN_RESTART_ON_CRASH"]
+NEURO.MAX_PLAYED_BLINDS = NEURO.CONFIG["RESEND_MODIFIER_BLIND_AMOUNT"]
+NEURO.PLAYED_BLINDS = 0
 
 local function hook_main_menu()
     local main_menu = Game.main_menu
@@ -200,8 +200,8 @@ local function hook_start_run()
         start_run(e,args)
 
          -- we do this so we dont send voucher information right after starting a new run as that would be a bit redundant
-        if PLAYED_BLINDS >= MAX_PLAYED_BLINDS - MAX_PLAYED_BLINDS / 3 then
-            PLAYED_BLINDS = 0
+        if NEURO.PLAYED_BLINDS >= NEURO.MAX_PLAYED_BLINDS - NEURO.MAX_PLAYED_BLINDS / 3 then
+            NEURO.PLAYED_BLINDS = 0
             Context.send(RunContext.get_all_modifier_desc(),true)
         end
     end
@@ -228,7 +228,7 @@ function Hook:hook_game()
 
         -- we cant use G.E_MANAGER since Game.update isnt being called
         -- so we have to manually check the time passed 
-        if NeuroConfig.get("RESTART_DELAY") <= 0 or love.timer.getTime() - crash_start_time >= NeuroConfig.get("RESTART_DELAY") then
+        if NEURO.CONFIG["RESTART_DELAY"] <= 0 or love.timer.getTime() - crash_start_time >= NEURO.CONFIG["RESTART_DELAY"] then
             SMODS.restart_game()
         end
     end

--- a/lovely/restart_crash.toml
+++ b/lovely/restart_crash.toml
@@ -12,7 +12,7 @@ end
 ''' # This is added by smods and can only be found in dumps made by lovely
 position = "before"
 payload = '''
-if G.can_restart then
+if NEURO.CAN_RESTART then
     G.on_crash_callback()
 end
 WEBSOCKET._client:close()

--- a/lovely/round_eval.toml
+++ b/lovely/round_eval.toml
@@ -10,7 +10,7 @@ pattern = "local scale = 0.9"
 position = "after"
 payload = '''
 if config then
-	ROUND_EVAL[#ROUND_EVAL + 1] = {config.name,config.dollars}
+	NEURO.ROUND_EVAL[#NEURO.ROUND_EVAL + 1] = {config.name,config.dollars}
 end
 '''
 match_indent = true

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,5 @@
+assert(SMODS.load_file("globals.lua"))()
+
 assert(SMODS.load_file("game-sdk/utils/table_utils.lua"))()
 
 assert(SMODS.load_file("game-sdk/sdk_string_consts.lua"))()
@@ -6,16 +8,13 @@ assert(SMODS.load_file("modifier_loc.lua"))()
 assert(SMODS.load_file("card_info.lua"))()
 assert(SMODS.load_file("deck_loc.lua"))()
 
-
-ModCache = assert(SMODS.load_file("module_cache.lua"))()
-NeuroConfig = ModCache.load("config_manager.lua")
+NEURO.MOD_CACHE = assert(SMODS.load_file("module_cache.lua"))()
+local config_mgr = NEURO.MOD_CACHE.load("config_manager.lua")
+NEURO.CONFIG = config_mgr.get_tbl()
 
 -- unlike require(), SMODS.load_file() doesn't guarantee files will only get loaded once
--- use ModCache.load() to get them loaded once
+-- use NEURO.MOD_CACHE.load() to get them loaded once
 -- theres definitely a way to get the sdk working with SMODS.load_file, but the entire sdk was written for require()
 -- and i wanted to do minimal changes to get it all working
-local Hook = ModCache.load("hook.lua")
-
-
-
+local Hook = NEURO.MOD_CACHE.load("hook.lua")
 Hook.hook_game()

--- a/modifier_loc.lua
+++ b/modifier_loc.lua
@@ -1,4 +1,4 @@
-Edition_Loc = {
+NEURO.LOCS.EDITION = {
 	e_base = {},
 	e_foil = {"extra"},
 	e_holo = {"extra"},
@@ -6,7 +6,7 @@ Edition_Loc = {
 	e_negative = {"extra"}
 }
 
-Enhancement_Loc = {
+NEURO.LOCS.ENHANCEMENT = {
 	m_bonus = {"bonus"},
 	m_mult = {"mult"},
 	m_wild = {},
@@ -21,7 +21,7 @@ Enhancement_Loc = {
 	m_steel = {"h_x_mult"}
 }
 
-Seal_Loc = {
+NEURO.LOCS.SEAL = {
 	Gold = {"gold_seal"},
 	Red = {"red_seal"},
 	Blue = {"blue_seal"},

--- a/playing_run.lua
+++ b/playing_run.lua
@@ -1,26 +1,26 @@
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local NeuroActionHandler = ModCache.load("game-sdk/actions/neuro_action_handler.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local NeuroActionHandler = NEURO.MOD_CACHE.load("game-sdk/actions/neuro_action_handler.lua")
 
-local UseHandCards = ModCache.load("custom-actions/use_hand_cards.lua")
-local JokerInteraction = ModCache.load("custom-actions/joker_interaction.lua")
-local UseConsumable = ModCache.load("custom-actions/use_consumables.lua")
-local PickCard = ModCache.load("custom-actions/pick_pack_card.lua")
-local PickPackCard = ModCache.load("custom-actions/pick_hand_pack_cards.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
-local SkipPack = ModCache.load("custom-actions/skip_pack.lua")
-local DeckTypes = ModCache.load("custom-actions/deck_type.lua")
-local PokerHandInfo = ModCache.load("custom-actions/get_poker_hand_info.lua")
-local ModifierInformation = ModCache.load("custom-actions/modifier_information.lua")
+local UseHandCards = NEURO.MOD_CACHE.load("custom-actions/use_hand_cards.lua")
+local JokerInteraction = NEURO.MOD_CACHE.load("custom-actions/joker_interaction.lua")
+local UseConsumable = NEURO.MOD_CACHE.load("custom-actions/use_consumables.lua")
+local PickCard = NEURO.MOD_CACHE.load("custom-actions/pick_pack_card.lua")
+local PickPackCard = NEURO.MOD_CACHE.load("custom-actions/pick_hand_pack_cards.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
+local SkipPack = NEURO.MOD_CACHE.load("custom-actions/skip_pack.lua")
+local DeckTypes = NEURO.MOD_CACHE.load("custom-actions/deck_type.lua")
+local PokerHandInfo = NEURO.MOD_CACHE.load("custom-actions/get_poker_hand_info.lua")
+local ModifierInformation = NEURO.MOD_CACHE.load("custom-actions/modifier_information.lua")
 
-local ExitShop = ModCache.load("custom-actions/shop-actions/exit_shop.lua")
-local RerollShop = ModCache.load("custom-actions/shop-actions/reroll_shop.lua")
-local BuyShopCard = ModCache.load("custom-actions/shop-actions/buy_shop_card.lua")
-local BuyShopBooster = ModCache.load("custom-actions/shop-actions/buy_shop_booster.lua")
-local BuyShopVoucher = ModCache.load("custom-actions/shop-actions/buy_shop_voucher.lua")
+local ExitShop = NEURO.MOD_CACHE.load("custom-actions/shop-actions/exit_shop.lua")
+local RerollShop = NEURO.MOD_CACHE.load("custom-actions/shop-actions/reroll_shop.lua")
+local BuyShopCard = NEURO.MOD_CACHE.load("custom-actions/shop-actions/buy_shop_card.lua")
+local BuyShopBooster = NEURO.MOD_CACHE.load("custom-actions/shop-actions/buy_shop_booster.lua")
+local BuyShopVoucher = NEURO.MOD_CACHE.load("custom-actions/shop-actions/buy_shop_voucher.lua")
 
-local Context = ModCache.load("game-sdk/messages/outgoing/context.lua")
-local RunHelper = ModCache.load("run_functions_helper.lua")
-local RunContext = ModCache.load("run_context.lua")
+local Context = NEURO.MOD_CACHE.load("game-sdk/messages/outgoing/context.lua")
+local RunHelper = NEURO.MOD_CACHE.load("run_functions_helper.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
 
 local PlayingRun = {}
 
@@ -173,7 +173,7 @@ function PlayingRun:hook_discard_cards()
     end
 end
 
-ROUND_EVAL = {} -- we set this in round_eval.toml
+NEURO.ROUND_EVAL = {} -- we set this in round_eval.toml
 local function get_round_info(round_eval)
     local context = "This is how much money you have made in the blind: "
     table.reverse(round_eval)
@@ -191,7 +191,7 @@ local function get_round_info(round_eval)
         ::continue::
     end
 
-    ROUND_EVAL = {}
+    NEURO.ROUND_EVAL = {}
     return context
 end
 
@@ -218,7 +218,7 @@ function PlayingRun:hook_round_eval()
     local update_round = add_round_eval_row
     function add_round_eval_row(config)
         update_round(config)
-        local round_eval = ROUND_EVAL
+        local round_eval = NEURO.ROUND_EVAL
 
         if config.name == "bottom" then -- bottom is the total
             Context.send(get_round_info(round_eval))
@@ -260,10 +260,10 @@ function PlayingRun:hook_new_round()
     local func = new_round
     function new_round()
         func()
-        PLAYED_BLINDS = PLAYED_BLINDS + 1
+        NEURO.PLAYED_BLINDS = NEURO.PLAYED_BLINDS + 1
 
-        if PLAYED_BLINDS >= MAX_PLAYED_BLINDS then
-            PLAYED_BLINDS = 0
+        if NEURO.PLAYED_BLINDS >= NEURO.MAX_PLAYED_BLINDS then
+            NEURO.PLAYED_BLINDS = 0
             Context.send(RunContext.get_all_modifier_desc() .. (#G.vouchers.cards > 0 and ("\n" .. "These are the vouchers you have gotten throughout this run " .. table.table_to_string(GetRunText.get_hand_details(G.vouchers.cards))) or ""), true)
         end
     end

--- a/pre_run_loc.lua
+++ b/pre_run_loc.lua
@@ -1,7 +1,7 @@
 require "functions/misc_functions"
 
-local ALLOWED_DECKS = NeuroConfig.get("ALLOWED_DECKS")
-local ALLOWED_STAKES = NeuroConfig.get("ALLOWED_STAKES")
+local ALLOWED_DECKS = NEURO.CONFIG["ALLOWED_DECKS"]
+local ALLOWED_STAKES = NEURO.CONFIG["ALLOWED_STAKES"]
 
 local GetText = {}
 
@@ -89,7 +89,7 @@ local function get_obj_names(center, set, key_indexed, whitelist)
 end
 
 function GetText:get_back_descriptions()
-    return get_lookup_tbl_descriptions(G.P_CENTER_POOLS.Back, "Back", ALLOWED_DECKS, Back_Loc)
+    return get_lookup_tbl_descriptions(G.P_CENTER_POOLS.Back, "Back", ALLOWED_DECKS, NEURO.LOCS.BACK)
 end
 
 function GetText:get_back_names(keys, allDecks)
@@ -99,7 +99,7 @@ function GetText:get_back_names(keys, allDecks)
 end
 
 function GetText:get_stake_descriptions()
-    return get_lookup_tbl_descriptions(G.P_CENTER_POOLS.Stake, "Stake", ALLOWED_STAKES, Stake_Loc)
+    return get_lookup_tbl_descriptions(G.P_CENTER_POOLS.Stake, "Stake", ALLOWED_STAKES, NEURO.LOCS.STAKE)
 end
 
 function GetText:get_stake_names(keys, allStakes)

--- a/run_context.lua
+++ b/run_context.lua
@@ -1,4 +1,4 @@
-local GetRunText = ModCache.load("get_run_text.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
 
 local RunContext = {}
 

--- a/run_functions_helper.lua
+++ b/run_functions_helper.lua
@@ -1,6 +1,6 @@
-local ActionWindow = ModCache.load("game-sdk/actions/action_window.lua")
-local GetRunText = ModCache.load("get_run_text.lua")
-local RunContext = ModCache.load("run_context.lua")
+local ActionWindow = NEURO.MOD_CACHE.load("game-sdk/actions/action_window.lua")
+local GetRunText = NEURO.MOD_CACHE.load("get_run_text.lua")
+local RunContext = NEURO.MOD_CACHE.load("run_context.lua")
 
 local RunHelper = {}
 
@@ -126,7 +126,7 @@ function RunHelper:get_consumable_validation(card,selected_hand_index,selected_a
         return true, success_string
     end
 
-    if table.contains_key(Non_Valid_Modify_Joker_Consumables,card.config.center_key) == true then
+    if table.contains_key(NEURO.CARD_INFO.MODIFY_JOKER_CONSUMABLE_OVERWRITE,card.config.center_key) == true then
         if #G.jokers.cards < 1 and selected_action == "Use" then
             success_string = "This card requires a joker to be used."
             return false, success_string
@@ -141,7 +141,7 @@ function RunHelper:get_consumable_validation(card,selected_hand_index,selected_a
     end
 
     -- these are cards that need room but do not list needed space in their config. These all add to joker
-    if table.contains_key(Non_Valid_Add_Joker_Consumables,card.config.center_key) == true then
+    if table.contains_key(NEURO.CARD_INFO.ADD_JOKER_CONSUMABLE_OVERWRITE,card.config.center_key) == true then
         if #G.jokers.cards >= G.jokers.config.card_limit and selected_action == "Use" then
             success_string = "You can not use this card as you already have the maximum amount of jokers."
             return false, success_string


### PR DESCRIPTION
Instead of having globals defined all over the place, they're all now under one global table. So instead of `PLAYED_BLINDS` it's `NEURO.PLAYED_BLINDS`.

All globals are defined with blank values in `globals.lua`